### PR TITLE
Fixes #41 the resource reference returned from constructRestAPI

### DIFF
--- a/provider/cmd/pulumi-resource-aws-apigateway/provider.ts
+++ b/provider/cmd/pulumi-resource-aws-apigateway/provider.ts
@@ -43,7 +43,7 @@ async function constructRestAPI(name: string, inputs: pulumi.Inputs,
         state: {
             url: restAPI.url,
             api: restAPI.api,
-            deployment: restAPI,
+            deployment: restAPI.deployment,
             stage: restAPI.stage,
             apiPolicy: restAPI.apiPolicy,
         },


### PR DESCRIPTION
Fixes #41 

I am debugging pulumi/pulumi-java#594 and I have a repro program that works correctly after this fix. The following Java program fails to preview.  Peeking on the gRPC conversation happening during `pulumi preview` this is suspect:

```json
{
  "fullMethod": "/pulumirpc.ResourceMonitor/RegisterResource",
  "request": {
    "type": "aws-apigateway:index:RestAPI",
    "name": "helloWorldApi",
    "parent": "urn:pulumi:tdev::java-repro::pulumi:pulumi:Stack::java-repro-tdev",
    ...
  },
  "response": {
    "urn": "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI::helloWorldApi",
    "object": {
      "api": ....
      "deployment": {
        "4dabf18193072939515e22adb298388d": "5cf8f73096256a8f31e491e813e4eb8e",
        "urn": "urn:pulumi:tdev::java-repro::aws-apigateway:index:RestAPI::helloWorldApi"
      }, ...
    }
}
```

That is, the deployment prop returns a reference to helloWorldApi itself (see how it matches the urn in the response). This causes a type error in Java and C# since a reference to Deployment is expected instead.

With this change the problem is gone.

Listing:

```java
package myproject;

import com.pulumi.Pulumi;
import com.pulumi.asset.AssetArchive;
import com.pulumi.asset.StringAsset;
import com.pulumi.aws.iam.Role;
import com.pulumi.aws.iam.RoleArgs;
import com.pulumi.aws.iam.RolePolicyAttachment;
import com.pulumi.aws.iam.RolePolicyAttachmentArgs;
import com.pulumi.aws.iam.enums.ManagedPolicy;
import com.pulumi.aws.lambda.Function;
import com.pulumi.aws.lambda.FunctionArgs;
import com.pulumi.aws.lambda.enums.Runtime;
import com.pulumi.awsapigateway.RestAPI;
import com.pulumi.awsapigateway.RestAPIArgs;
import com.pulumi.awsapigateway.enums.Method;
import com.pulumi.awsapigateway.inputs.RouteArgs;

import java.util.Map;

public class App {

    public static void main(String[] args) {
        Pulumi.run(ctx -> {
            var role = new Role("lambdaRole", RoleArgs.builder()
                    .assumeRolePolicy("""
                            {
                              "Version": "2012-10-17",
                              "Statement": [
                                {
                                  "Effect": "Allow",
                                  "Principal": {
                                    "Service": "lambda.amazonaws.com"
                                  },
                                  "Action": "sts:AssumeRole"
                                }
                              ]
                            }""")
                    .build()
            );

            var lambdaBasicExecutionRole = new RolePolicyAttachment("basicExecutionRole", RolePolicyAttachmentArgs.builder()
                    .role(role.name())
                    .policyArn(ManagedPolicy.AWSLambdaBasicExecutionRole.getValue())
                    .build());

            var funcCode = new StringAsset("""
                                           exports.handler = async (event) => {
                                               return {
                                                   statusCode: 200,
                                                       body: "Hello, world!",
                                                       };
                                           }""");

            var func = new Function("helloWorldFunction",
                                    FunctionArgs.builder()
                                    .role(role.arn())
                                    .handler("index.handler")
                                    .runtime(Runtime.NodeJS12dX)
                                    .code(new AssetArchive(Map.of("index.js", funcCode)))
                                    .build());

            var api = new RestAPI("helloWorldApi", RestAPIArgs.builder()
                                  .routes(
                                          RouteArgs.builder()
                                          .path("/")
                                          .method(Method.GET)
                                          .eventHandler(func)
                                          .build()
                                          )
                                  .build());

        });
    }
}
```