### PR TITLE
Rebuild workflows

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -32,28 +32,24 @@ env:
   # THIS GITHUB_TOKEN IS A REQUIREMENT TO BE ABLE TO WRITE TO GH RELEASES
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # IF YOU NEED TO PUBLISH A NPM PACKAGE THEN ENSURE A NPM_TOKEN SECRET IS SET
-  # AND PUBLISH_NPM: TRUE. IF YOU WANT TO PUBLISH TO A PRIVATE NPM REGISTRY
+  # IF YOU WANT TO PUBLISH TO A PRIVATE NPM REGISTRY
   # THEN ENSURE THE NPM_REGISTRY_URL IS CHANGED
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  PUBLISH_NPM: true
   NPM_REGISTRY_URL: https://registry.npmjs.org
   # IF YOU NEED TO PUBLISH A NUGET PACKAGE THEN ENSURE AN NUGET_PUBLISH_KEY
-  # SECRET IS SET AND PUBLISH_NUGET: TRUE. IF YOU WANT TO PUBLISH TO AN ALTERNATIVE
+  # SECRET IS SET. IF YOU WANT TO PUBLISH TO AN ALTERNATIVE
   # NPM REGISTRY THEN ENSURE THE NPM_REGISTRY_URL IS CHANGED
   NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   NUGET_FEED_URL: https://api.nuget.org/v3/index.json
-  PUBLISH_NUGET: true
-  # IF YOU NEED TO PUBLISH A PYPI PACKAGE THEN ENSURE AN PYPI_API_TOKEN
-  # SECRET IS SET AND PUBLISH_PYPI: TRUE. IF YOU WANT TO PUBLISH TO AN ALTERNATIVE
+  # ENSURE AN PYPI_API_TOKEN SECRET IS SET
+  # IF YOU WANT TO PUBLISH TO AN ALTERNATIVE
   # PYPI REGISTRY THEN ENSURE THE PYPI_REPOSITORY_URL IS SET. IF YOU ARE USING AN API_TOKEN THEN
   # YOU DO NOT NEED TO CHANGE THE PYPI_USERNAME (__token__) , IF YOU ARE USING PASSWORD AUTHENTICATION THEN YOU WILL
   # NEED TO CHANGE TO USE THE CORRECT PASSWORD
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYPI_USERNAME: "pulumi"
   PYPI_REPOSITORY_URL: ""
-  PUBLISH_PYPI: true
-  # IF YOU NEED TO PUBLISH A JAVA PACKAGE THEN ENSURE PUBLISH_JAVA: TRUE.
   # YOU WILL NEED TO SPECIFY A STAGING SERVER AND ITS CREDENTIALS AS WELL AS THE
   # SIGNING INFORMATION FOR THE PACKAGE
   SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
@@ -61,7 +57,6 @@ env:
   SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
   PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_JAVA: true
 jobs:
   publish_binary:
     name: Publish Provider Binary
@@ -167,25 +162,25 @@ jobs:
       - name: Mock Publish Java SDK
         if: ${{ inputs.publishJava == 'true'}}
         run: find sdk/java -type f
-      # - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
+      # - if: ${{ matrix.language == 'python' && inputs.publishPython == 'true' }}
       #   name: Publish package to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
       #   with:
       #     user: ${{ env.PYPI_USERNAME }}
       #     password: ${{ env.PYPI_PASSWORD }}
       #     packages_dir: ${{github.workspace}}/sdk/python/bin/dist
-      # - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
+      # - if: ${{ matrix.language == 'nodejs' && inputs.publishNpm == 'true' }}
       #   uses: JS-DevTools/npm-publish@v1
       #   with:
       #     access: "public"
       #     token: ${{ env.NPM_TOKEN }}
       #     package: ${{github.workspace}}/sdk/nodejs/bin/package.json
-      # - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
+      # - if: ${{ matrix.language == 'dotnet' && inputs.publishNuget == 'true' }}
       #   name: publish nuget package
       #   run: |
       #     dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg -s ${{ env.NUGET_FEED_URL }} -k ${{ env.NUGET_PUBLISH_KEY }}
       #     echo "done publishing packages"
-      # - if: ${{ matrix.language == 'java' && env.PUBLISH_JAVA == 'true' }}
+      # - if: ${{ matrix.language == 'java' && inputs.publishJava == 'true' }}
       #   name: publish java package
       #   uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
       #   with:

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,3 +1,33 @@
+name: release
+on:
+  repository_dispatch:
+    types: [release-test]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to be released"
+        type: string
+        required: true
+      publishProvider:
+        description: "Publish provider binaries (to GH & S3)"
+        default: true
+        type: boolean
+      publishNpm:
+        description: "Publish Node.js SDK"
+        default: true
+        type: boolean
+      publishNuget:
+        description: "Publish .NET SDK"
+        default: true
+        type: boolean
+      publishPython:
+        description: "Publish Python SDK"
+        default: true
+        type: boolean
+      publishJava:
+        description: "Publish Java SDK"
+        default: true
+        type: boolean
 env:
   # THIS GITHUB_TOKEN IS A REQUIREMENT TO BE ABLE TO WRITE TO GH RELEASES
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,8 +69,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -48,10 +76,6 @@ jobs:
       - uses: MOZGIII/install-ldid-action@v1
         with:
           tag: v2.1.5-procursus2
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.1.0
-        with:
-          repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Configure AWS Credentials
@@ -64,18 +88,20 @@ jobs:
           role-external-id: upload-pulumi-release
           role-session-name: uploader@githubActions
           role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - run: make build_provider
       - name: Create Provider Binaries
-        run: make dist
-      - name: Upload Provider Binaries
-        run: aws s3 cp dist s3://get.pulumi.com/releases/plugins/ --recursive
-      - name: Create GH Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            dist/*.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        run: make dist VERSION=${{ inputs.version }}
+      - name: Mock Upload
+        if: ${{ inputs.publishProvider == 'true'}}
+        run: echo "Uploading..."
+      # - name: Upload Provider Binaries
+      #   run: aws s3 cp dist s3://get.pulumi.com/releases/plugins/ --recursive
+      # - name: Create GH Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: |
+      #       dist/*.tar.gz
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     strategy:
       fail-fast: true
       matrix:
@@ -88,16 +114,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.goversion }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.1.0
-        with:
-          repo: pulumi/pulumictl
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Setup Node
@@ -120,10 +140,12 @@ jobs:
           distribution: temurin
           java-version: ${{matrix.javaversion}}
       - name: Set PACKAGE_VERSION to Env
-        run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+        run: echo "PACKAGE_VERSION=$PACKAGE_VERSION" >>
           $GITHUB_ENV
       - name: Build SDK
-        run: make build_${{ matrix.language }}_sdk
+        run: make build_${{ matrix.language }}_sdk VERSION=${{ inputs.version }}
       - name: Check worktree clean
         run: |
           git update-index -q --refresh
@@ -133,35 +155,47 @@ jobs:
               git diff
               exit 1
           fi
-      - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
-        name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ env.PYPI_USERNAME }}
-          password: ${{ env.PYPI_PASSWORD }}
-          packages_dir: ${{github.workspace}}/sdk/python/bin/dist
-      - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          access: "public"
-          token: ${{ env.NPM_TOKEN }}
-          package: ${{github.workspace}}/sdk/nodejs/bin/package.json
-      - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
-        name: publish nuget package
-        run: |
-          dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg -s ${{ env.NUGET_FEED_URL }} -k ${{ env.NUGET_PUBLISH_KEY }}
-          echo "done publishing packages"
-      - if: ${{ matrix.language == 'java' && env.PUBLISH_JAVA == 'true' }}
-        name: publish java package
-        uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
-        with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-          build-root-directory: ./sdk/java
-          gradle-version: 7.4.1
-      - if: ${{ matrix.language == 'go' }}
-        name: Add SDK version tag
-        run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
-          sdk/v$(pulumictl get version --language generic)
+      - name: Mock Publish Python SDK
+        if: ${{ inputs.publishPython == 'true'}}
+        run: find sdk/python/bin/dist -type f
+      - name: Mock Publish Node SDK
+        if: ${{ inputs.publishNpm == 'true'}}
+        run: find sdk/nodejs/bin -type f
+      - name: Mock Publish Node SDK
+        if: ${{ inputs.publishNuget == 'true'}}
+        run: find sdk/dotnet/bin/Debug -type f
+      - name: Mock Publish Java SDK
+        if: ${{ inputs.publishJava == 'true'}}
+        run: find sdk/java -type f
+      # - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
+      #   name: Publish package to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: ${{ env.PYPI_USERNAME }}
+      #     password: ${{ env.PYPI_PASSWORD }}
+      #     packages_dir: ${{github.workspace}}/sdk/python/bin/dist
+      # - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
+      #   uses: JS-DevTools/npm-publish@v1
+      #   with:
+      #     access: "public"
+      #     token: ${{ env.NPM_TOKEN }}
+      #     package: ${{github.workspace}}/sdk/nodejs/bin/package.json
+      # - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
+      #   name: publish nuget package
+      #   run: |
+      #     dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg -s ${{ env.NUGET_FEED_URL }} -k ${{ env.NUGET_PUBLISH_KEY }}
+      #     echo "done publishing packages"
+      # - if: ${{ matrix.language == 'java' && env.PUBLISH_JAVA == 'true' }}
+      #   name: publish java package
+      #   uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      #   with:
+      #     arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+      #     build-root-directory: ./sdk/java
+      #     gradle-version: 7.4.1
+      # - if: ${{ matrix.language == 'go' }}
+      #   name: Add SDK version tag
+      #   run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
+      #     sdk/v$(pulumictl get version --language generic)
     strategy:
       fail-fast: false
       matrix:
@@ -181,10 +215,3 @@ jobs:
           - 18.x
         pythonversion:
           - "3.9"
-name: release
-"on":
-  push:
-    tags:
-      - v*.*.*
-      - '!v*.*.*-**'
-      - '!v0.x.x'

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -28,6 +28,22 @@ on:
         description: "Publish Java SDK"
         default: true
         type: boolean
+      dotnetVersion:
+        description: Version of dotnet to install
+        default: "3.1.301"
+      goVersion:
+        description: Version of Go to install
+        default: "1.19.x"
+      javaVersion:
+        description: Version of Java to install
+        default: "11"
+      nodeVersion:
+        description: Version of Node.js to install
+        default: "18.x"
+      pythonVersion:
+        description: Version of Python to install
+        default: "3.9"
+
 env:
   # THIS GITHUB_TOKEN IS A REQUIREMENT TO BE ABLE TO WRITE TO GH RELEASES
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,7 +83,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ inputs.nodeVersion }}
       - uses: MOZGIII/install-ldid-action@v1
         with:
           tag: v2.1.5-procursus2
@@ -97,43 +113,47 @@ jobs:
       #       dist/*.tar.gz
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-    strategy:
-      fail-fast: true
-      matrix:
-        nodeversion:
-          - 18.x
   publish_sdk:
     name: Publish SDKs
     runs-on: ubuntu-latest
     needs: publish_binary
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - nodejs
+          - python
+          - dotnet
+          - go
+          - java
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version: ${{ inputs.goVersion }}
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{matrix.nodeversion}}
+          node-version: ${{ inputs.nodeVersion }}
           registry-url: ${{env.NPM_REGISTRY_URL}}
       - name: Setup DotNet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{matrix.dotnetverson}}
+          dotnet-version: ${{ inputs.dotnetverson }}
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: ${{matrix.pythonversion}}
+          python-version: ${{ inputs.pythonVersion }}
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           cache: gradle
           distribution: temurin
-          java-version: ${{matrix.javaversion}}
+          java-version: ${{ inputs.javaVersion }}
       - name: Set PACKAGE_VERSION to Env
         env:
           PACKAGE_VERSION: ${{ inputs.version }}
@@ -191,22 +211,4 @@ jobs:
       #   name: Add SDK version tag
       #   run: git tag sdk/v$(pulumictl get version --language generic) && git push origin
       #     sdk/v$(pulumictl get version --language generic)
-    strategy:
-      fail-fast: false
-      matrix:
-        dotnetversion:
-          - 3.1.301
-        goversion:
-          - 1.19.x
-        language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
-        javaversion:
-          - 11
-        nodeversion:
-          - 18.x
-        pythonversion:
-          - "3.9"
+

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,8 +8,8 @@ jobs:
     name: Dispatch Release Workflow
     runs-on: ubuntu-latest
     steps:
-      - name: Invoke release workflow
-        uses: benc-uk/workflow-dispatch@v1
+      - name: Dispatch Release Workflow
+        uses: benc-uk/workflow-dispatch@v1.2.2
         with:
           workflow: release-test.yaml
           inputs: '{ "version": "${{ github.ref_name }}" }'

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,15 @@
+name: release
+on:
+  push:
+    tags:
+      - v*.*.*
+jobs:
+  dispatch_publish:
+    name: Dispatch Release Workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke release workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: release-test.yaml
+          inputs: '{ "version": "${{ github.ref_name }}" }'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION         := $(shell pulumictl get version)
+VERSION ?= 0.0.1
 
 PACK            := aws-apigateway
 PROJECT         := github.com/pulumi/pulumi-${PACK}
@@ -13,12 +13,11 @@ JAVA_GEN_VERSION := v0.5.0
 WORKING_DIR     := $(shell pwd)
 SCHEMA_PATH     := ${WORKING_DIR}/schema.yaml
 
-generate:: gen_go_sdk gen_nodejs_sdk gen_python_sdk gen_dotnet_sdk gen_java_sdk
-
 build:: build_provider build_nodejs_sdk build_python_sdk build_dotnet_sdk build_go_sdk build_java_sdk
 
-install:: install_provider install_nodejs_sdk install_dotnet_sdk
+generate:: gen_go_sdk gen_nodejs_sdk gen_python_sdk gen_dotnet_sdk gen_java_sdk
 
+install:: install_provider install_nodejs_sdk install_dotnet_sdk
 
 # Provider
 
@@ -49,12 +48,11 @@ gen_dotnet_sdk::
 	rm -rf sdk/dotnet
 	cd provider/cmd/${CODEGEN} && go run . dotnet ../../../sdk/dotnet ${SCHEMA_PATH}
 
-build_dotnet_sdk:: DOTNET_VERSION := $(shell pulumictl get version --language dotnet)
 build_dotnet_sdk:: gen_dotnet_sdk
 	cd sdk/dotnet/ && \
 		echo "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
-		echo "${DOTNET_VERSION}" >version.txt && \
-		dotnet build /p:Version=${DOTNET_VERSION}
+		echo "${VERSION}" >version.txt && \
+		dotnet build /p:Version=${VERSION}
 
 install_dotnet_sdk:: build_dotnet_sdk
 	rm -rf ${WORKING_DIR}/nuget
@@ -67,7 +65,6 @@ gen_nodejs_sdk::
 	rm -rf sdk/nodejs
 	cd provider/cmd/${CODEGEN} && go run . nodejs ../../../sdk/nodejs ${SCHEMA_PATH}
 
-build_nodejs_sdk:: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs_sdk:: gen_nodejs_sdk
 	cd sdk/nodejs/ && \
 		echo "module fake_nodejs_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
@@ -76,7 +73,7 @@ build_nodejs_sdk:: gen_nodejs_sdk
 		yarn run tsc && \
 		cp -R scripts/ bin && \
 		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
-		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json && \
+		sed -i.bak -e "s/\$${VERSION}/v$(VERSION)/g" ./bin/package.json && \
 		rm ./bin/package.json.bak
 
 install_nodejs_sdk:: build_nodejs_sdk
@@ -90,13 +87,12 @@ gen_python_sdk::
 	cd provider/cmd/${CODEGEN} && go run . python ../../../sdk/python ${SCHEMA_PATH}
 	cp ${WORKING_DIR}/README.md sdk/python
 
-build_python_sdk:: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python_sdk:: gen_python_sdk
 	cd sdk/python/ && \
 		echo "module fake_python_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \
 		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
+		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
 		rm ./bin/setup.py.bak && \
 		cd ./bin && python3 setup.py build sdist
 
@@ -109,7 +105,7 @@ gen_java_sdk:: bin/pulumi-java-gen
 	rm -rf sdk/java
 	$(WORKING_DIR)/bin/$(JAVA_GEN) generate --schema ${SCHEMA_PATH} --out sdk/java --build gradle-nexus
 
-build_java_sdk:: PACKAGE_VERSION := $(shell pulumictl get version --language generic)
+build_java_sdk:: PACKAGE_VERSION := $(VERSION)
 build_java_sdk::
 	cd sdk/java/ && \
 		echo "module fake_java_module // Exclude this directory from Go tools\n\ngo 1.17" > go.mod && \

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,6 +2,40 @@
 
 Easily create AWS API Gateway REST APIs using Pulumi. This component exposes the Crosswalk for AWS functionality documented in the [Pulumi AWS API Gateway guide](https://www.pulumi.com/docs/guides/crosswalk/aws/api-gateway/) as a package available in all Pulumi languages.
 
+## Installing
+
+This package is available in many languages in the standard packaging formats.
+
+### Node.js (Java/TypeScript)
+
+To use from JavaScript or TypeScript in Node.js, install using either `npm`:
+
+    npm install @pulumi/aws-apigateway
+
+or `yarn`:
+
+    yarn add @pulumi/aws-apigateway
+
+### Python
+
+To use from Python, install using `pip`:
+
+    pip install pulumi-aws-apigateway
+
+### Go
+
+To use from Go, use `go get` to grab the latest version of the library
+
+    go get github.com/pulumi/pulumi-aws-apigateway/sdk
+
+### .NET
+
+To use from .NET, install using `dotnet add package`:
+
+    dotnet add package Pulumi.AwsApiGateway
+
+## Example
+
 Python:
 
 ```py
@@ -14,7 +48,7 @@ api = apigateway.RestAPI('api', routes=[
 pulumi.export('url', api.url)
 ```
 
-Go: 
+Go:
 
 ```go
 getMethod := apigateway.MethodGET


### PR DESCRIPTION
- Remove pulumictl - set version explicitly in make and workflow.
- Can't publish pre-release versions for now because syntax varies per language
- We need have something like pulumictl but which just reformats versions per language - not interacting with git.
- Make `build` the default makefile target
- Add workflow options to disable individual publish steps
- Default local builds to 0.0.1
- Remove unshallow for tags
- Disable old release working on prerelease tag pushes
- For backward compatibility, add tag workflow to invoke new publish workflow
- Use mock actions until we've tested fully