### PR TITLE
Relax @pulumi/aws dependency

### DIFF
--- a/provider/cmd/pulumi-resource-aws-apigateway/package.json
+++ b/provider/cmd/pulumi-resource-aws-apigateway/package.json
@@ -4,7 +4,7 @@
     "pulumi-resource-aws-apigateway": "bin/index.js"
   },
   "dependencies": {
-    "@pulumi/aws": "5.16.2",
+    "@pulumi/aws": "^5.16.2",
     "@pulumi/pulumi": "^3.34.1",
     "aws-lambda": "^1.0.7",
     "yaml": "^2.1.1"


### PR DESCRIPTION
Currently, we download multiple `pulumi-aws` plugins for new API Gateway projects:

```
$ pulumi plugin rm --all --yes
$ pulumi new aws-serverless-go
...
$ pulumi plugin ls
NAME            KIND      VERSION  SIZE    INSTALLED      LAST USED
aws             resource  5.23.0   467 MB  2 minutes ago  1 minute ago
aws             resource  5.16.2   420 MB  7 seconds ago  4 seconds ago
aws-apigateway  resource  1.0.1    98 MB   3 minutes ago  1 minute ago
```

This change relaxes the dependency on @pulumi/aws to track the latest minor version of @pulumi/aws (assuming this is what we want, of course!).