### PR TITLE
Fix support for apiKeySource

### DIFF
--- a/examples/apikeysource/Pulumi.yaml
+++ b/examples/apikeysource/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: apigateway-apikeysource
+runtime: nodejs
+description: Testing the `akikeysource for `API`.

--- a/examples/apikeysource/data.ts
+++ b/examples/apikeysource/data.ts
@@ -1,0 +1,15 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const apikeysource = "HEADER";

--- a/examples/apikeysource/index.ts
+++ b/examples/apikeysource/index.ts
@@ -1,0 +1,38 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import * as apigateway from "@pulumi/aws-apigateway";
+import * as data from "./data";
+
+const f = new aws.lambda.CallbackFunction("f", {
+  callback: async (ev, ctx) => {
+    console.log(JSON.stringify(ev));
+    return {
+      statusCode: 200,
+      body: "goodbye",
+    };
+  },
+});
+
+const api = new apigateway.RestAPI("authorizer-api", {
+  apiKeySource: data.apikeysource,
+  routes: [{
+    path: "/",
+    method: "GET",
+    eventHandler: f,
+  }],
+}, { version: "" });
+
+export const apiKeySource = api.api.apiKeySource;

--- a/examples/apikeysource/index.ts
+++ b/examples/apikeysource/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as apigateway from "@pulumi/aws-apigateway";
 import * as data from "./data";
@@ -35,4 +36,13 @@ const api = new apigateway.RestAPI("authorizer-api", {
   }],
 }, { version: "" });
 
-export const apiKeySource = api.api.apiKeySource;
+
+// TODO[pulumi/pulumi-aws-apigateway#111]: The `api` output is (incorrectly) a string not an object
+// so we cannot read it's output.  Workaround this by looking up the API by name.
+var apiRead: any = {};
+if (!pulumi.runtime.isDryRun()) {
+  apiRead = aws.apigateway.getRestApiOutput({
+    name: api.url.apply(_ => "authorizer-api"),
+  });
+}
+export const apiKeySource = apiRead.apiKeySource;

--- a/examples/apikeysource/package.json
+++ b/examples/apikeysource/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "api",
+    "version": "0.0.1",
+    "license": "Apache-2.0",
+    "scripts": {
+        "build": "tsc"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-apigateway": "1.1.0-alpha.3",
+        "@pulumi/pulumi": "^3.3.1"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/examples/apikeysource/step2/data.ts
+++ b/examples/apikeysource/step2/data.ts
@@ -1,0 +1,15 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const apikeysource = "AUTHORIZER";

--- a/examples/apikeysource/tsconfig.json
+++ b/examples/apikeysource/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -1,13 +1,14 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
-//go:build nodejs || all
-// +build nodejs all
 
 package examples
 
 import (
-	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"path"
 	"path/filepath"
 	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSimpleTs(t *testing.T) {
@@ -15,6 +16,26 @@ func TestSimpleTs(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: filepath.Join(getCwd(t), "simple"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestAccApiKeySource(t *testing.T) {
+	test := getBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir:     path.Join(getCwd(t), "./apikeysource"),
+			Verbose: true,
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      "./apikeysource/step2",
+					Additive: true,
+					ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+						apiKeySource := stack.Outputs["apiKeySource"].(string)
+						assert.Equal(t, "AUTHORIZER", apiKeySource)
+					},
+				},
+			},
 		})
 
 	integration.ProgramTest(t, &test)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -24,8 +24,7 @@ func TestSimpleTs(t *testing.T) {
 func TestAccApiKeySource(t *testing.T) {
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:     path.Join(getCwd(t), "./apikeysource"),
-			Verbose: true,
+			Dir: path.Join(getCwd(t), "./apikeysource"),
 			EditDirs: []integration.EditDir{
 				{
 					Dir:      "./apikeysource/step2",

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -22,7 +22,10 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	awsRegion := getRegion(t)
 	return integration.ProgramTestOptions{
 		SkipRefresh: true,
-		Quick: true,
+		Quick:       true,
+		Dependencies: []string{
+			"@pulumi/aws-apigateway",
+		},
 		Config: map[string]string{
 			"aws:region": awsRegion,
 		},

--- a/provider/cmd/pulumi-resource-aws-apigateway/apigateway/api.ts
+++ b/provider/cmd/pulumi-resource-aws-apigateway/apigateway/api.ts
@@ -653,6 +653,9 @@ export function createAPI(
       name: ifUndefined(restApiArgs.name, title),
       binaryMediaTypes: ifUndefined(restApiArgs.binaryMediaTypes, ["*/*"]),
       body: swaggerString,
+      // We pass this in directly, because setting it in the Swagger doesn't cause
+      // it to take affect, it must be passed directly to the RestAPI constructor as well.
+      apiKeySource: args.apiKeySource,
     },
     { parent }
   );


### PR DESCRIPTION
Ports the fix from https://github.com/pulumi/pulumi-awsx/pull/1159 into this package.

Requires an awkward workaround for #111 (the workaround also takes a dependency on the currently broken behaviour, so this test will start failing when #111 is fixed). 

Fixes #110. 