### PR TITLE
Fix getRegion function to work even when region not explicitely specified

### DIFF
--- a/provider/cmd/pulumi-resource-aws-apigateway/apigateway/utils.ts
+++ b/provider/cmd/pulumi-resource-aws-apigateway/apigateway/utils.ts
@@ -117,24 +117,6 @@ export function hasTrueBooleanMember(obj: any, memberName: string | number | sym
 }
 
 /** @internal */
-export function getRegionFromOpts(opts: pulumi.CustomResourceOptions): pulumi.Output<aws.Region> {
-    if (opts.parent) {
-        return getRegion(opts.parent);
-    }
-
-    return getRegionFromProvider(opts.provider);
-}
-
-
-/** @internal */
 export function getRegion(res: pulumi.Resource): pulumi.Output<aws.Region> {
-    // A little strange, but all we're doing is passing a fake type-token simply to get
-    // the AWS provider from this resource.
-    const provider = res.getProvider ? res.getProvider("aws::") : undefined;
-    return getRegionFromProvider(provider);
-}
-
-function getRegionFromProvider(provider: pulumi.ProviderResource | undefined) {
-    const region = provider ? (<any>provider).region : undefined;
-    return region || aws.config.region;
+    return aws.getRegionOutput({}, { parent: res }).apply(region => region.name as aws.Region);
 }

--- a/provider/cmd/pulumi-resource-aws-apigateway/apigateway/utils.ts
+++ b/provider/cmd/pulumi-resource-aws-apigateway/apigateway/utils.ts
@@ -118,5 +118,6 @@ export function hasTrueBooleanMember(obj: any, memberName: string | number | sym
 
 /** @internal */
 export function getRegion(res: pulumi.Resource): pulumi.Output<aws.Region> {
+    // uses the provider from the parent resource to fetch the region
     return aws.getRegionOutput({}, { parent: res }).apply(region => region.name as aws.Region);
 }


### PR DESCRIPTION
Previously the getRegion function returned undefined in cases where the region wasn't explicitely defined (e.g. `AWS_REGION` environment variable).
This change fixes that by using the provider's built in method for resolving the region.

Fixes #91 
