### PR TITLE
Fix release badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Actions Status](https://github.com/pulumi/pulumi-aws-apigateway/workflows/release/badge.svg)](https://github.com/pulumi/pulumi-aws-apigateway/actions)
+[![Actions Status](https://github.com/pulumi/pulumi-aws-apigateway/actions/workflows/release.yml/badge.svg)](https://github.com/pulumi/pulumi-aws-apigateway/actions)
 [![Slack](http://www.pulumi.com/images/docs/badges/slack.svg)](https://slack.pulumi.com)
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Faws-apigateway.svg)](https://www.npmjs.com/package/@pulumi/aws-apigateway)
 [![Python version](https://badge.fury.io/py/pulumi-aws-apigateway.svg)](https://pypi.org/project/pulumi-aws-apigateway)


### PR DESCRIPTION
The link to the release badge was broken.
Updating the link according to: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name