### PR TITLE
Fix authorizer validation to enable reusing authorizers

### DIFF
--- a/examples/apigateway-multi-auth/Pulumi.yaml
+++ b/examples/apigateway-multi-auth/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: apigateway-multi-auth
+runtime: nodejs
+description: An API Gateway with a custom lambda authorizer

--- a/examples/apigateway-multi-auth/auth-lambda.ts
+++ b/examples/apigateway-multi-auth/auth-lambda.ts
@@ -1,0 +1,67 @@
+import * as awslambda from "aws-lambda";
+
+type AuthorizerLambda = (event: awslambda.APIGatewayAuthorizerEvent) => Promise<awslambda.APIGatewayAuthorizerResult>
+
+export function authorizerLambda(): AuthorizerLambda {
+    return async (event: awslambda.APIGatewayAuthorizerEvent) => {
+        try {
+            return await authenticate(event);
+        }
+        catch (err) {
+            console.log(err);
+            // Tells API Gateway to return a 401 Unauthorized response
+            throw new Error("Unauthorized");
+        }
+    }
+}
+
+// Extract and return the Bearer Token from the Lambda event parameters
+function getToken(event: awslambda.APIGatewayAuthorizerEvent): string | undefined {
+    if (!event.type || event.type !== "TOKEN") {
+        throw new Error('Expected "event.type" parameter to have value "TOKEN"');
+    }
+
+    const tokenString = event.authorizationToken;
+    if (!tokenString) {
+        return undefined;
+    }
+
+    const match = tokenString.match(/^Bearer (.*)$/);
+    if (!match) {
+        // Invalid Authorization token - does not match "Bearer .*"
+        return undefined;
+    }
+    return match[1];
+}
+
+// Check the Token is valid
+async function authenticate(event: awslambda.APIGatewayAuthorizerEvent): Promise<awslambda.APIGatewayAuthorizerResult> {
+    console.log(event);
+    const token = getToken(event);
+
+    // Dummy check for token, in a real-world scenario, you would verify the token 
+    const effect = token ? "Allow" : "Deny";
+
+    const methodArn = getMethodArn(event);
+    console.log(`Method ARN: ${methodArn}`);
+    return {
+        principalId: "me",
+        policyDocument: {
+            Version: "2012-10-17",
+            Statement: [{
+                Action: "execute-api:Invoke",
+                Effect: effect,
+                Resource: methodArn,
+            }],
+        },
+    };
+}
+
+function getMethodArn(event: awslambda.APIGatewayAuthorizerEvent): string {
+    if (!event.methodArn) {
+        throw new Error('Expected "event.methodArn" parameter to be set');
+    }
+
+    const arnPartials = event.methodArn.split("/");
+    return arnPartials.slice(0, 2).join("/") + "/*";
+}

--- a/examples/apigateway-multi-auth/index.ts
+++ b/examples/apigateway-multi-auth/index.ts
@@ -1,0 +1,44 @@
+import * as aws from "@pulumi/aws";
+import { authorizerLambda } from "./auth-lambda";
+import * as apigateway from "@pulumi/aws-apigateway";
+
+const f = new aws.lambda.CallbackFunction("f", {
+    callback: async (ev, ctx) => {
+      console.log(JSON.stringify(ev));
+      return {
+        statusCode: 200,
+        body: "Hello, World!",
+      };
+    },
+  });
+
+const authorizer = {
+    authType: "custom",
+    authorizerName: "jwt-rsa-custom-authorizer",
+    parameterName: "Authorization",
+    identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
+    type: "token",
+    parameterLocation: "header",
+    authorizerResultTtlInSeconds: 300,
+    handler: new aws.lambda.CallbackFunction("authorizer", {
+        callback: authorizerLambda(),
+    }),
+}
+
+// Create multiple routes with the same authorizer.
+const routes: apigateway.types.input.RouteArgs[] = [];
+for (let i = 0; i < 15; i++) {
+    routes.push({
+      path: `/route${i}`,
+      method: "ANY",
+      eventHandler: f,
+      authorizers: [authorizer]
+  });
+}
+
+const api = new apigateway.RestAPI("multi-auth-api", {
+    routes: routes,
+    binaryMediaTypes: ["application/json"],
+});
+
+export const url = api.url;

--- a/examples/apigateway-multi-auth/package.json
+++ b/examples/apigateway-multi-auth/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "apigateway-multi-auth",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0",
+        "@types/aws-lambda": "^8.10.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "@pulumi/aws-apigateway": "^2.5.0"
+    }
+}

--- a/examples/apigateway-multi-auth/tsconfig.json
+++ b/examples/apigateway-multi-auth/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -3,6 +3,7 @@
 package examples
 
 import (
+	"fmt"
 	"path"
 	"path/filepath"
 	"testing"
@@ -100,6 +101,34 @@ func TestAuth(t *testing.T) {
 
 				// Make a request to the API Gateway endpoint without an auth token and expect a 401 to verify the authorizer is working
 				retryGETRequestUntil(t, url, nil, 401, 60*time.Second)
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
+func TestMultiAuth(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			// Tests whether all routes re-use the same authorizer. This is done by creating 15 routes that all use the same
+			// authorizer. API Gateway only allows 10 authorizers per API Gateway, so if the authorizer is not re-used, the
+			// test will fail.
+			Dir: filepath.Join(getCwd(t), "apigateway-multi-auth"),
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Test the authorizer for each route
+				for idx := range 15 {
+					url := stackInfo.Outputs["url"].(string) + "route" + fmt.Sprint(idx)
+
+					validAuthHeaders := map[string]string{"Authorization": "Bearer DUMMY_TOKEN"}
+
+					// Make a request to the API Gateway endpoint with an auth token to verify it's working
+					integration.AssertHTTPResultWithRetry(t, url, validAuthHeaders, 60*time.Second, func(body string) bool {
+						return assert.Equal(t, "Hello, World!", body, "Body should equal 'Hello, World!', got %s", body)
+					})
+
+					// Make a request to the API Gateway endpoint without an auth token and expect a 401 to verify the authorizer is working
+					retryGETRequestUntil(t, url, nil, 401, 60*time.Second)
+				}
 			},
 		})
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-aws-apigateway/examples
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.4

--- a/examples/test-programs/authorizer-validation/base-params/Pulumi.yaml
+++ b/examples/test-programs/authorizer-validation/base-params/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: authorizer-validation
+runtime: nodejs
+description: Test for the authorizer validation

--- a/examples/test-programs/authorizer-validation/base-params/auth-lambda.ts
+++ b/examples/test-programs/authorizer-validation/base-params/auth-lambda.ts
@@ -1,0 +1,67 @@
+import * as awslambda from "aws-lambda";
+
+type AuthorizerLambda = (event: awslambda.APIGatewayAuthorizerEvent) => Promise<awslambda.APIGatewayAuthorizerResult>
+
+export function authorizerLambda(): AuthorizerLambda {
+    return async (event: awslambda.APIGatewayAuthorizerEvent) => {
+        try {
+            return await authenticate(event);
+        }
+        catch (err) {
+            console.log(err);
+            // Tells API Gateway to return a 401 Unauthorized response
+            throw new Error("Unauthorized");
+        }
+    }
+}
+
+// Extract and return the Bearer Token from the Lambda event parameters
+function getToken(event: awslambda.APIGatewayAuthorizerEvent): string | undefined {
+    if (!event.type || event.type !== "TOKEN") {
+        throw new Error('Expected "event.type" parameter to have value "TOKEN"');
+    }
+
+    const tokenString = event.authorizationToken;
+    if (!tokenString) {
+        return undefined;
+    }
+
+    const match = tokenString.match(/^Bearer (.*)$/);
+    if (!match) {
+        // Invalid Authorization token - does not match "Bearer .*"
+        return undefined;
+    }
+    return match[1];
+}
+
+// Check the Token is valid
+async function authenticate(event: awslambda.APIGatewayAuthorizerEvent): Promise<awslambda.APIGatewayAuthorizerResult> {
+    console.log(event);
+    const token = getToken(event);
+
+    // Dummy check for token, in a real-world scenario, you would verify the token 
+    const effect = token ? "Allow" : "Deny";
+
+    const methodArn = getMethodArn(event);
+    console.log(`Method ARN: ${methodArn}`);
+    return {
+        principalId: "me",
+        policyDocument: {
+            Version: "2012-10-17",
+            Statement: [{
+                Action: "execute-api:Invoke",
+                Effect: effect,
+                Resource: methodArn,
+            }],
+        },
+    };
+}
+
+function getMethodArn(event: awslambda.APIGatewayAuthorizerEvent): string {
+    if (!event.methodArn) {
+        throw new Error('Expected "event.methodArn" parameter to be set');
+    }
+
+    const arnPartials = event.methodArn.split("/");
+    return arnPartials.slice(0, 2).join("/") + "/*";
+}

--- a/examples/test-programs/authorizer-validation/base-params/index.ts
+++ b/examples/test-programs/authorizer-validation/base-params/index.ts
@@ -1,0 +1,58 @@
+import * as aws from "@pulumi/aws";
+import { authorizerLambda } from "./auth-lambda";
+import * as apigateway from "@pulumi/aws-apigateway";
+
+const f = new aws.lambda.CallbackFunction("f", {
+    callback: async (ev, ctx) => {
+      console.log(JSON.stringify(ev));
+      return {
+        statusCode: 200,
+        body: "Hello, World!",
+      };
+    },
+  });
+
+const authLambda = new aws.lambda.CallbackFunction("authorizer", {
+  callback: authorizerLambda(),
+});
+
+// Create multiple routes with the same authorizer.
+const routes: apigateway.types.input.RouteArgs[] = [
+  {
+    path: `/route1`,
+    method: "ANY",
+    eventHandler: f,
+    authorizers: [{
+      authType: "custom",
+      authorizerName: "lambda-authorizer",
+      parameterName: "Authorization",
+      identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
+      type: "token",
+      parameterLocation: "header",
+      authorizerResultTtlInSeconds: 300,
+      handler: authLambda,
+    }]
+  },
+  {
+    path: `/route2`,
+    method: "ANY",
+    eventHandler: f,
+    authorizers: [{
+      authType: "custom",
+      authorizerName: "lambda-authorizer",
+      parameterName: "Other", // <- here's the diff
+      identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
+      type: "token",
+      parameterLocation: "header",
+      authorizerResultTtlInSeconds: 300,
+      handler: authLambda,
+    }]
+  }
+];
+
+const api = new apigateway.RestAPI("multi-auth-api", {
+    routes: routes,
+    binaryMediaTypes: ["application/json"],
+});
+
+export const url = api.url;

--- a/examples/test-programs/authorizer-validation/base-params/index.ts
+++ b/examples/test-programs/authorizer-validation/base-params/index.ts
@@ -16,7 +16,7 @@ const authLambda = new aws.lambda.CallbackFunction("authorizer", {
   callback: authorizerLambda(),
 });
 
-// Create multiple routes with the same authorizer.
+// Creates two routes with different authorizers that have the same name
 const routes: apigateway.types.input.RouteArgs[] = [
   {
     path: `/route1`,

--- a/examples/test-programs/authorizer-validation/base-params/package.json
+++ b/examples/test-programs/authorizer-validation/base-params/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "authorizer-validation",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0",
+        "@types/aws-lambda": "^8.10.0"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/pulumi": "^3.113.0",
+        "@pulumi/aws-apigateway": "^2.5.0"
+    }
+}

--- a/examples/test-programs/authorizer-validation/base-params/tsconfig.json
+++ b/examples/test-programs/authorizer-validation/base-params/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/test-programs/authorizer-validation/cognito/index.ts
+++ b/examples/test-programs/authorizer-validation/cognito/index.ts
@@ -14,7 +14,7 @@ const f = new aws.lambda.CallbackFunction("f", {
 const userPoolA = new aws.cognito.UserPool("userpoolA", {});
 const userPoolB = new aws.cognito.UserPool("userpoolB", {});
 
-// Create multiple routes with the same authorizer.
+// Creates two routes with different authorizers that have the same name
 const routes: apigateway.types.input.RouteArgs[] = [
   {
     path: `/route1`,
@@ -39,7 +39,7 @@ const routes: apigateway.types.input.RouteArgs[] = [
       identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
       parameterLocation: "header",
       authorizerResultTtlInSeconds: 300,
-      providerARNs: [userPoolA.arn],
+      providerARNs: [userPoolA.arn], // <- here's the diff, using userPoolA instead of userPoolB
     }]
   }
 ];

--- a/examples/test-programs/authorizer-validation/cognito/index.ts
+++ b/examples/test-programs/authorizer-validation/cognito/index.ts
@@ -1,0 +1,52 @@
+import * as aws from "@pulumi/aws";
+import * as apigateway from "@pulumi/aws-apigateway";
+
+const f = new aws.lambda.CallbackFunction("f", {
+    callback: async (ev, ctx) => {
+      console.log(JSON.stringify(ev));
+      return {
+        statusCode: 200,
+        body: "Hello, World!",
+      };
+    },
+  });
+
+const userPoolA = new aws.cognito.UserPool("userpoolA", {});
+const userPoolB = new aws.cognito.UserPool("userpoolB", {});
+
+// Create multiple routes with the same authorizer.
+const routes: apigateway.types.input.RouteArgs[] = [
+  {
+    path: `/route1`,
+    method: "ANY",
+    eventHandler: f,
+    authorizers: [{
+      authorizerName: "cognito-authorizer",
+      parameterName: "Authorization",
+      identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
+      parameterLocation: "header",
+      authorizerResultTtlInSeconds: 300,
+      providerARNs: [userPoolB.arn],
+    }]
+  },
+  {
+    path: `/route2`,
+    method: "ANY",
+    eventHandler: f,
+    authorizers: [{
+      authorizerName: "cognito-authorizer",
+      parameterName: "Authorization",
+      identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
+      parameterLocation: "header",
+      authorizerResultTtlInSeconds: 300,
+      providerARNs: [userPoolA.arn],
+    }]
+  }
+];
+
+const api = new apigateway.RestAPI("multi-auth-api", {
+    routes: routes,
+    binaryMediaTypes: ["application/json"],
+});
+
+export const url = api.url;

--- a/examples/test-programs/authorizer-validation/lambda/index.ts
+++ b/examples/test-programs/authorizer-validation/lambda/index.ts
@@ -1,0 +1,58 @@
+import * as aws from "@pulumi/aws";
+import { authorizerLambda } from "./auth-lambda";
+import * as apigateway from "@pulumi/aws-apigateway";
+
+const f = new aws.lambda.CallbackFunction("f", {
+    callback: async (ev, ctx) => {
+      console.log(JSON.stringify(ev));
+      return {
+        statusCode: 200,
+        body: "Hello, World!",
+      };
+    },
+  });
+
+// Create multiple routes with the same authorizer.
+const routes: apigateway.types.input.RouteArgs[] = [
+  {
+    path: `/route1`,
+    method: "ANY",
+    eventHandler: f,
+    authorizers: [{
+      authType: "custom",
+      authorizerName: "lambda-authorizer",
+      parameterName: "Authorization",
+      identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
+      type: "token",
+      parameterLocation: "header",
+      authorizerResultTtlInSeconds: 300,
+      handler: new aws.lambda.CallbackFunction("authorizerA", {
+        callback: authorizerLambda(),
+      }),
+    }]
+  },
+  {
+    path: `/route2`,
+    method: "ANY",
+    eventHandler: f,
+    authorizers: [{
+      authType: "custom",
+      authorizerName: "lambda-authorizer",
+      parameterName: "Authorization",
+      identityValidationExpression: "^Bearer [-0-9a-zA-Z\._]*$",
+      type: "token",
+      parameterLocation: "header",
+      authorizerResultTtlInSeconds: 300,
+      handler: new aws.lambda.CallbackFunction("authorizerB", {
+        callback: authorizerLambda(),
+      }),
+    }]
+  }
+];
+
+const api = new apigateway.RestAPI("multi-auth-api", {
+    routes: routes,
+    binaryMediaTypes: ["application/json"],
+});
+
+export const url = api.url;

--- a/examples/test-programs/authorizer-validation/lambda/index.ts
+++ b/examples/test-programs/authorizer-validation/lambda/index.ts
@@ -12,7 +12,7 @@ const f = new aws.lambda.CallbackFunction("f", {
     },
   });
 
-// Create multiple routes with the same authorizer.
+// Creates two routes with different authorizers that have the same name
 const routes: apigateway.types.input.RouteArgs[] = [
   {
     path: `/route1`,
@@ -43,7 +43,7 @@ const routes: apigateway.types.input.RouteArgs[] = [
       type: "token",
       parameterLocation: "header",
       authorizerResultTtlInSeconds: 300,
-      handler: new aws.lambda.CallbackFunction("authorizerB", {
+      handler: new aws.lambda.CallbackFunction("authorizerB", { // <- here's the diff, using a different lambda function
         callback: authorizerLambda(),
       }),
     }]

--- a/provider/cmd/pulumi-resource-aws-apigateway/apigateway/api.ts
+++ b/provider/cmd/pulumi-resource-aws-apigateway/apigateway/api.ts
@@ -841,7 +841,8 @@ function createSwaggerSpec(
 }
 
 /**
- * Checks for duplicate authorizers in the given array.
+ * Checks for duplicate authorizers in the given array. A duplicate authorizer is one that has the same name but
+ * different configuration then another authorizer.
  * @param authorizers - The array of authorizers to check.
  * @returns A pulumi.Output containing the name of the duplicate authorizer, if found; otherwise, undefined.
  */

--- a/provider/cmd/pulumi-resource-aws-apigateway/apigateway/api.ts
+++ b/provider/cmd/pulumi-resource-aws-apigateway/apigateway/api.ts
@@ -23,7 +23,7 @@ import * as pulumi from "@pulumi/pulumi";
 
 import type * as awslambda from "aws-lambda";
 
-import { getRegion, ifUndefined, isInstance, sha1hash } from "./utils";
+import { getRegion, ifUndefined, sha1hash } from "./utils";
 
 import { apiKeySecurityDefinition } from "./apikey";
 import * as cognitoAuthorizer from "./cognitoAuthorizer";
@@ -43,7 +43,6 @@ import {
   SwaggerSpec,
 } from "./swagger_json";
 import { isDeepStrictEqual } from "util";
-import { deepStrictEqual } from "assert";
 
 export type Request = awslambda.APIGatewayProxyEvent;
 

--- a/provider/cmd/pulumi-resource-aws-apigateway/apigateway/cognitoAuthorizer.ts
+++ b/provider/cmd/pulumi-resource-aws-apigateway/apigateway/cognitoAuthorizer.ts
@@ -16,6 +16,7 @@
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
+import { LambdaAuthorizer } from "./lambdaAuthorizer";
 
 /**
  * CognitoAuthorizer provides the definition for a Cognito User Pools Authorizer for API Gateway.
@@ -131,4 +132,10 @@ export function getCognitoAuthorizer(
     authorizerResultTtlInSeconds: args.authorizerResultTtlInSeconds,
     methodsToAuthorize: args.methodsToAuthorize,
   };
+}
+
+export function isCognitoAuthorizer(
+  authorizer: LambdaAuthorizer | CognitoAuthorizer
+): authorizer is CognitoAuthorizer {
+  return (<CognitoAuthorizer>authorizer).providerARNs !== undefined;
 }


### PR DESCRIPTION
This equality check here will never be truthy: https://github.com/pulumi/pulumi-aws-apigateway/blob/main/provider/cmd/pulumi-resource-aws-apigateway/apigateway/api.ts#L1010
Those inputs come into the provider via GRPC and get re-assembled as objects, thus all authorizer always get different references. Even if their underlying values are equal.

fixes #156