### PR TITLE
Regenerate SDK and build all SDKs as part of PR/main branch workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Install Pulumi CLI
         uses: pulumi/actions@v4
 
+      # Required by Makefile::bin/pulumi-java-gen
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: pulumi/pulumictl
+
       - name: Set PACKAGE_VERSION to Env
         env:
           PACKAGE_VERSION: ${{ inputs.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,23 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Setup DotNet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          cache: gradle
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
       - uses: MOZGIII/install-ldid-action@v1
         with:
           tag: v2.1.5-procursus2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,9 @@ jobs:
           $GITHUB_ENV
 
       - name: Build & Install Provider & SDKs
-        run: make install
+        run: |
+          make build
+          make install
 
       - name: Check worktree clean
         run: |

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,4 +1,4 @@
-[![Actions Status](https://github.com/pulumi/pulumi-aws-apigateway/workflows/release/badge.svg)](https://github.com/pulumi/pulumi-aws-apigateway/actions)
+[![Actions Status](https://github.com/pulumi/pulumi-aws-apigateway/actions/workflows/release.yml/badge.svg)](https://github.com/pulumi/pulumi-aws-apigateway/actions)
 [![Slack](http://www.pulumi.com/images/docs/badges/slack.svg)](https://slack.pulumi.com)
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Faws-apigateway.svg)](https://www.npmjs.com/package/@pulumi/aws-apigateway)
 [![Python version](https://badge.fury.io/py/pulumi-aws-apigateway.svg)](https://pypi.org/project/pulumi-aws-apigateway)


### PR DESCRIPTION
Only the nodejs and dotnet SDK were built on PRs/main branch. But we should do that for all SDKs.

fixes #158