### PR TITLE
chore: Ensure a single copy of @pulumi/pulumi dependency

### DIFF
--- a/provider/cmd/pulumi-resource-aws-apigateway/package.json
+++ b/provider/cmd/pulumi-resource-aws-apigateway/package.json
@@ -9,6 +9,9 @@
     "aws-lambda": "^1.0.7",
     "yaml": "^2.2.2"
   },
+  "resolutions": {
+    "@pulumi/pulumi": "3.142.0"
+  },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.108",
     "@types/mime": "^3.0.1",


### PR DESCRIPTION
Having two versions of `@pulumi/pulumi` linked into the provider may cause problems.

See for example:

- https://github.com/pulumi/pulumi/issues/18057#issuecomment-2549986660
- https://github.com/pulumi/pulumi-aws-apigateway/pull/177

Two versions of `@pulumi/pulumi` may be installed if `@pulumi/aws` dependency contradicts the direct dependency on that package.

This change takes advantage of a YARN specific feature called "resolutions" that will make sure that only one version, the one specified in resolutions, is selected by YARN for the lockfile:

https://yarnpkg.com/lang/en/docs/selective-version-resolutions/

When using NPM, a similar feature is called overrides.

https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides