### PR TITLE
chore: Improve deps handling and renovate interaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,4 +140,4 @@ test:
 
 renovate:	build
 
-.PHONY: build build_provider build_nodejs_sdk build_python_sdk build_dotnet_sdk build_go_sdk build_java_sdk generate gen_go_sdk gen_nodejs_sdk gen_python_sdk gen_dotnet_sdk gen_java_sdk install install_provider install_nodejs_sdk install_dotnet_sdk renovate
+.PHONY: build build_dotnet_sdk build_go_sdk build_java_sdk build_nodejs_sdk build_provider build_python_sdk gen_dotnet_sdk gen_go_sdk gen_java_sdk gen_nodejs_sdk gen_python_sdk generate install install_dotnet_sdk install_nodejs_sdk install_provider renovate

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ install: install_provider install_nodejs_sdk install_dotnet_sdk
 build_provider:
 	cd provider/cmd/${PROVIDER}/ && \
 		yarn install --frozen-lockfile && \
+		yarn check-duplicate-deps && \
 		yarn tsc && \
 		cp package.json ../../../schema.yaml ./bin && \
 		sed -i.bak -e "s/\$${VERSION}/$(PROVIDER_VERSION)/g" bin/package.json && \

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ test:
 	@export PATH
 	cd examples && go test -v -json -tags=all -timeout 2h . 2>&1 | tee /tmp/gotest.log | gotestfmt
 
-renovate:	build
+renovate: generate
 
 bin/pulumictl: bin/pulumictl-version.$(PULUMICTL_VERSION).txt
 	@mkdir -p bin

--- a/provider/cmd/pulumi-resource-aws-apigateway/package.json
+++ b/provider/cmd/pulumi-resource-aws-apigateway/package.json
@@ -15,9 +15,12 @@
     "@types/node": "^16.0.0",
     "pkg": "^5.6.0",
     "prettier": "^2.7.1",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0",
+    "yarn-deduplicate": "^6.0.2"
   },
   "scripts": {
-    "format": "prettier -w ."
+    "format": "prettier -w .",
+    "dedupe-deps": "yarn-deduplicate",
+    "check-duplicate-deps": "yarn-deduplicate --fail"
   }
 }

--- a/provider/cmd/pulumi-resource-aws-apigateway/yarn.lock
+++ b/provider/cmd/pulumi-resource-aws-apigateway/yarn.lock
@@ -662,6 +662,11 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz#d785ee90c52d7cc020e249c948c36f7b32d1e217"
   integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abbrev@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
@@ -953,6 +958,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
 commander@^3.0.2:
   version "3.0.2"
@@ -2368,7 +2378,7 @@ sax@>=0.6.0:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
   integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
 
-semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2, semver@^7.5.3:
+semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -2671,6 +2681,11 @@ treeverse@^3.0.0:
   resolved "https://registry.yarnpkg.com/treeverse/-/treeverse-3.0.0.tgz#dd82de9eb602115c6ebd77a574aae67003cb48c8"
   integrity sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==
 
+tslib@^2.5.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
 tuf-js@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tuf-js/-/tuf-js-2.2.1.tgz#fdd8794b644af1a75c7aaa2b197ddffeb2911b56"
@@ -2917,6 +2932,16 @@ yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yarn-deduplicate@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-6.0.2.tgz#63498d2d4c3a8567e992a994ce0ab51aa5681f2e"
+  integrity sha512-Efx4XEj82BgbRJe5gvQbZmEO7pU5DgHgxohYZp98/+GwPqdU90RXtzvHirb7hGlde0sQqk5G3J3Woyjai8hVqA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    commander "^10.0.1"
+    semver "^7.5.0"
+    tslib "^2.5.0"
 
 yocto-queue@^1.0.0:
   version "1.1.1"

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,9 +3,10 @@
   extends: ["github>pulumi/renovate-config//default.json5"],
   packageRules: [
     {
-      // Update metadata when aws-apigateway is bumped.
-      matchDatasources: ["npm"],
-      matchPackageNames: ["@pulumi/aws-apigateway"],
+      matchDatasources: ["npm", "go", "golang-version"],
+      // Dependent files need to be rebuilt when key dependencies change.
+      //
+      // https://docs.renovatebot.com/configuration-options/#postupgradetasks
       postUpgradeTasks: {
         commands: ["make renovate"],
         executionMode: "branch", // Only run once.


### PR DESCRIPTION
Aimed at making sure PRs like https://github.com/pulumi/pulumi-aws-apigateway/pull/177 may succeed:

- ensure deps are not duplicated (replicate from pulumi-awsx)
- make renovate does make generate without rebuilding (replicate from pulumi-aws)
- ensure pulumictl is installed on-demand enabling make renovate (replicate from pulumi-eks)
