### PR TITLE
chore: fix renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ bin/pulumi-java-gen-version.$(JAVA_GEN_VERSION).txt:
 	@rm -f bin/pulumi-java-gen.v*
 	@echo "$(JAVA_GEN_VERSION)" >"$@"
 
-bin/pulumi-java-gen: bin/pulumi-java-gen-version.$(JAVA_GEN_VERSION).txt bin/pulumictl
+bin/pulumi-java-gen: bin/pulumi-java-gen-version.$(JAVA_GEN_VERSION).txt
 	@mkdir -p bin/
-	bin/pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java
+	pulumictl download-binary -n pulumi-language-java -v $(JAVA_GEN_VERSION) -r pulumi/pulumi-java
 
 gen_java_sdk: bin/pulumi-java-gen
 	rm -rf sdk/java
@@ -150,14 +150,5 @@ test:
 	cd examples && go test -v -json -tags=all -timeout 2h . 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 renovate: generate
-
-bin/pulumictl: bin/pulumictl-version.$(PULUMICTL_VERSION).txt
-	@mkdir -p bin
-	@go install "github.com/pulumi/pulumictl/cmd/pulumictl@$(PULUMICTL_VERSION)"
-	@cp $(GOPATH)/bin/pulumictl "$@"
-
-bin/pulumictl-version.$(PULUMICTL_VERSION).txt:
-	@mkdir -p bin
-	@echo $(PULUMICTL_VERSION) > "$@"
 
 .PHONY: build build_dotnet_sdk build_go_sdk build_java_sdk build_nodejs_sdk build_provider build_python_sdk gen_dotnet_sdk gen_go_sdk gen_java_sdk gen_nodejs_sdk gen_python_sdk generate install install_dotnet_sdk install_nodejs_sdk install_provider renovate


### PR DESCRIPTION
PR #180 updated the Makefile to add these targets. It mentions basing it
on pulumi-eks, but it looks like the configuration for downloading pulumictl is not used by
any other repo and is causing problems. All the others just assume that
it is available so maybe something changed recently with our renovate
config to allow for that assumption.

re #184