### PR TITLE
Convert yaml schema to json

### DIFF
--- a/provider/cmd/pulumi-resource-aws-apigateway/schema.json
+++ b/provider/cmd/pulumi-resource-aws-apigateway/schema.json
@@ -1,487 +1,507 @@
----
-name: aws-apigateway
-description: Pulumi Amazon Web Services (AWS) API Gateway Components.
-repository: https://github.com/pulumi/pulumi-aws-apigateway
-license: Apache-2.0
-logoUrl: https://raw.githubusercontent.com/pulumi/pulumi-aws-apigateway/main/assets/logo.png
-displayName: AWS API Gateway
-publisher: Pulumi
-keywords:
-  - pulumi
-  - aws
-  - apigateway
-  - category/cloud
-  - kind/component
-types:
-  aws-apigateway:index:Route:
-    type: object
-    properties:
-      path:
-        type: string
-        plain: true
-        description: |
-          The path on the API that will serve this route.  If not prefixed with `/`,
-          then a `/` will be added automatically to the beginning.
-      method:
-        "$ref": "#/types/aws-apigateway:index:Method"
-        plain: true
-        description: |
-          The REST method of the route to match.  Only valid with `eventHandler` or `data` routes.
-      eventHandler:
-        "$ref": "/aws/v6.59.1/schema.json#/resources/aws:lambda%2Ffunction:Function"
-        description: |
-          A Lambda function which will handle the route for the given path and method.
-      localPath:
-        type: string
-        plain: true
-        description: |
-          The local path on disk to create static S3 resources for.  Files will be uploaded into S3
-          objects, and directories will be recursively walked into.
-      contentType:
-        type: string
-        plain: true
-        description: |
-          The `content-type` to serve the file as.  Only valid when `localPath` points to a file.  If
-          `localPath` points to a directory, the content types for all files will be inferred.
-      index:
-        oneOf:
-          - type: string
-            plain: true
-          - type: boolean
-            plain: true
-        plain: true
-        description: |
-          By default a `localPath` hosting static content will also serve 'index.html' in response to a request on a directory.
-          To disable this pass `false` or supply a new index document name.
-      data:
-        "$ref": pulumi.json#/Any
-        plain: true
-        description: |
-          A raw Swagger object to include verbatim in the integration for this path.
-      target:
-        "$ref": "#/types/aws-apigateway:index:Target"
-        description: |
-          The target for an integration route (see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-integration-types.html).
-      requiredParameters:
-        type: array
-        items:
-          "$ref": "#/types/aws-apigateway:index:RequiredParameter"
-          plain: true
-        plain: true
-        description: |
-          Required Parameters to validate. If the request validator is set to ALL or PARAMS_ONLY, api
-          gateway will validate these before sending traffic to the event handler.
-      requestValidator:
-        "$ref": "#/types/aws-apigateway:index:RequestValidator"
-        plain: true
-        description: |
-          Request Validator specifies the validator to use at the method level. This will override anything
-          defined at the API level.
-      apiKeyRequired:
-        type: boolean
-        plain: true
-        description: |
-          If true, an API key will be required for this route. The source for the API Key can be set at
-          the API level and by default, the source will be the HEADER.
-      authorizers:
-        type: array
-        items:
-          "$ref": "#/types/aws-apigateway:index:Authorizer"
-          plain: true
-        plain: true
-        description: |
-          Authorizers allows you to define Lambda authorizers be applied for authorization when the
-          the route is called.
-      iamAuthEnabled:
-        type: boolean
-        plain: true
-        description: |
-          By default, the route method auth type is set to `NONE`. If true, the auth type will be
-          set to `AWS_IAM`.
-    required:
-      - path
-    description: |
-      A route that that APIGateway should accept and forward to some type of destination. All routes
-      have an incoming path that they match against.  However, destinations are determined by the kind
-      of the route.
-  aws-apigateway:index:Target:
-    type: object
-    properties:
-      type:
-        "$ref": "#/types/aws-apigateway:index:IntegrationType"
-        description: |
-          Specifies an API method integration type. The valid value is one of the following:
-
-          * `aws`: for integrating the API method request with an AWS service action, including the Lambda
-          function-invoking action. With the Lambda function-invoking action, this is referred to as
-          the Lambda custom integration. With any other AWS service action, this is known as AWS
-          integration.
-
-          * `aws_proxy`: for integrating the API method request with the Lambda function-invoking action
-          with the client request passed through as-is. This integration is also referred to as the
-          Lambda proxy integration.
-
-          * `http`: for integrating the API method request with an HTTP endpoint, including a private HTTP
-          endpoint within a VPC. This integration is also referred to as the HTTP custom integration.
-
-          * `http_proxy`: for integrating the API method request with an HTTP endpoint, including a private
-          HTTP endpoint within a VPC, with the client request passed through as-is. This is also
-          referred to as the HTTP proxy integration.
-
-          * `mock`: for integrating the API method request with API Gateway as a "loop-back" endpoint
-          without invoking any backend.
-      httpMethod:
-        type: string
-        const: ANY
-        description: |
-          Specifies the integration's HTTP method type.  Currently, the only supported type is 'ANY'.
-      uri:
-        type: string
-        description: |
-          Specifies Uniform Resource Identifier (URI) of the integration endpoint.
-
-          For HTTP or HTTP_PROXY integrations, the URI must be a fully formed, encoded HTTP(S) URL
-          according to the RFC-3986 specification, for either standard integration, where
-          connectionType is not VPC_LINK, or private integration, where connectionType is VPC_LINK. For
-          a private HTTP integration, the URI is not used for routing.
-
-          For AWS or AWS_PROXY integrations, the URI is of the form
-          arn:aws:apigateway:{region}:{subdomain.service|service}:path|action/{service_api}. Here,
-          {Region} is the API Gateway region (e.g., us-east-1); {service} is the name of the integrated
-          AWS service (e.g., s3); and {subdomain} is a designated subdomain supported by certain AWS
-          service for fast host-name lookup. action can be used for an AWS service action-based API,
-          using an Action={name}&{p1}={v1}&p2={v2}... query string. The ensuing {service_api} refers to
-          a supported action {name} plus any required input parameters. Alternatively, path can be used
-          for an AWS service path-based API. The ensuing service_api refers to the path to an AWS
-          service resource, including the region of the integrated AWS service, if applicable. For
-          example, for integration with the S3 API of GetObject, the uri can be either
-          arn:aws:apigateway:us-west-2:s3:action/GetObject&Bucket={bucket}&Key={key} or
-          arn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}.
-      connectionType:
-        "$ref": "#/types/aws-apigateway:index:IntegrationConnectionType"
-        description: |
-          The type of the network connection to the integration endpoint. The valid value is `INTERNET`
-          for connections through the public routable internet or `VPC_LINK` for private connections
-          between API Gateway and a network load balancer in a VPC. The default value is `INTERNET`.
-      connectionId:
-        type: string
-        description: |
-          The (id) of the VpcLink used for the integration when connectionType=VPC_LINK and undefined,
-          otherwise.
-      passthroughBehaviour:
-        "$ref": "#/types/aws-apigateway:index:IntegrationPassthroughBehavior"
-        description: |
-          Specifies how the method request body of an unmapped content type will be passed through the
-          integration request to the back end without transformation.
-
-          The valid value is one of the following:
-
-          * `WHEN_NO_MATCH`: passes the method request body through the integration request to the back end
-          without transformation when the method request content type does not match any content type
-          associated with the mapping templates defined in the integration request.
-
-          * `WHEN_NO_TEMPLATES`: passes the method request body through the integration request to the back
-          end without transformation when no mapping template is defined in the integration request. If
-          a template is defined when this option is selected, the method request of an unmapped
-          content-type will be rejected with an HTTP 415 Unsupported Media Type response.
-
-          * `NEVER`: rejects the method request with an HTTP 415 Unsupported Media Type response when
-          either the method request content type does not match any content type associated with the
-          mapping templates defined in the integration request or no mapping template is defined in the
-          integration request.
-
-          Defaults to `WHEN_NO_MATCH` if unspecified.
-    required:
-      - type
-  aws-apigateway:index:Method:
-    type: string
-    enum:
-      - value: ANY
-      - value: GET
-      - value: PUT
-      - value: POST
-      - value: DELETE
-      - value: PATCH
-      - value: OPTIONS
-      - value: HEAD
-  aws-apigateway:index:RequestValidator:
-    type: string
-    enum:
-      - value: ALL
-      - value: PARAMS_ONLY
-      - value: BODY_ONLY
-  aws-apigateway:index:APIKeySource:
-    type: string
-    enum:
-      - value: HEADER
-      - value: AUTHORIZER
-  aws-apigateway:index:IntegrationConnectionType:
-    type: string
-    enum:
-      - value: INTERNET
-      - value: VPC_LINK
-  aws-apigateway:index:IntegrationType:
-    type: string
-    enum:
-      - value: aws
-      - value: aws_proxy
-      - value: http
-      - value: http_proxy
-      - value: mock
-  aws-apigateway:index:IntegrationPassthroughBehavior:
-    type: string
-    enum:
-      - value: when_no_match
-      - value: when_no_templates
-      - value: never
-  aws-apigateway:index:SwaggerGatewayResponse:
-    type: object
-    properties:
-      statusCode:
-        type: number
-      responseTemplates:
-        type: object
-        additionalProperties:
-          type: string
-      responseParameters:
-        type: object
-        additionalProperties:
-          type: string
-  aws-apigateway:index:RequiredParameter:
-    type: object
-    properties:
-      name:
-        type: string
-      in:
-        type: string
-        enum:
-          - value: path
-          - value: query
-          - value: header
-  aws-apigateway:index:Authorizer:
-    type: object
-    properties:
-      authorizerName:
-        type: string
-        plain: true
-        description: |
-          The name for the Authorizer to be referenced as. This must be unique for each unique
-          authorizer within the API. If no name if specified, a name will be generated for you.
-      parameterName:
-        type: string
-        plain: true
-        description: |
-          parameterName is the name of the header or query parameter containing the authorization
-          token. Must be "Unused" for multiple identity sources.
-      parameterLocation:
-        type: string
-        enum:
-          - value: query
-          - value: header
-        plain: true
-        description: |
-          Defines where in the request API Gateway should look for identity information. The value must
-          be "header" or "query". If there are multiple identity sources, the value must be "header".
-      authType:
-        type: string
-        plain: true
-        description: |
-          Specifies the authorization mechanism for the client. Typical values are "oauth2" or "custom".
-      type:
-        type: string
-        enum:
-          - value: token
-          - value: request
-        plain: true
-        description: |
-          The type of the authorizer. This value must be one of the following:
-          - "token", for an authorizer with the caller identity embedded in an authorization token
-          - "request", for an authorizer with the caller identity contained in request parameters
-      handler:
-        "$ref": "/aws/v6.59.1/schema.json#/resources/aws:lambda%2Ffunction:Function"
-        description: |
-          The authorizerHandler specifies information about the authorizing Lambda.
-      identitySource:
-        type: array
-        items:
-          type: string
-          plain: true
-        plain: true
-        description: |
-          List of mapping expressions of the request parameters as the identity source. This indicates
-          where in the request identity information is expected. Applicable for the authorizer of the
-          "request" type only. Example: ["method.request.header.HeaderAuth1",
-          "method.request.querystring.QueryString1"]
-      identityValidationExpression:
-        type: string
-        plain: true
-        description: |
-          A regular expression for validating the token as the incoming identity. It only invokes the
-          authorizer's lambda if there is a match, else it will return a 401. This does not apply to
-          REQUEST Lambda Authorizers. Example: "^x-[a-z]+".
-      authorizerResultTtlInSeconds:
-        type: number
-        plain: true
-        description: |
-          The number of seconds during which the resulting IAM policy is cached. Default is 300s. You
-          can set this value to 0 to disable caching. Max value is 3600s. Note - if you are sharing an
-          authorizer across more than one route you will want to disable the cache or else it will
-          cause problems for you.
-      providerARNs:
-        type: array
-        items:
-          type: string
-        plain: true
-        description: |
-          The ARNs of the Cognito User Pools to use.
-      methodsToAuthorize:
-        type: array
-        items:
-          type: string
-          plain: true
-        plain: true
-        description: |
-          For method authorization, you can define resource servers and custom scopes by specifying the
-          "resource-server/scope". e.g. ["com.hamuta.movies/drama.view",
-          "http://my.resource.com/file.read"] For more information on resource servers and custom
-          scopes visit the AWS documentation -
-          https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-define-resource-servers.html
-    required:
-      - parameterName
-    description: |
-      LambdaAuthorizer provides the definition for a custom Authorizer for API Gateway.
-resources:
-  aws-apigateway:index:RestAPI:
-    isComponent: true
-    inputProperties:
-      routes:
-        type: array
-        items:
-          "$ref": "#/types/aws-apigateway:index:Route"
-          plain: true
-        plain: true
-        description: |
-          Routes to use to initialize the APIGateway.  These will be used to create the Swagger
-          specification for the API.
-
-          Either `swaggerString` or `routes` must be specified.
-      swaggerString:
-        type: string
-        description: |
-          A Swagger specification already in string form to use to initialize the APIGateway.  Note
-          that you must manually provide permission for any route targets to be invoked by API Gateway
-          when using `swaggerString`.
-
-          Either `swaggerString` or `routes` must be specified.
-      stageName:
-        type: string
-        description: |
-          The stage name for your API. This will get added as a base path to your API url.
-      requestValidator:
-        "$ref": "#/types/aws-apigateway:index:RequestValidator"
-        plain: true
-        description: |
-          Request Validator specifies the validator to use at the API level. Note method level validators
-          override this.
-      apiKeySource:
-        "$ref": "#/types/aws-apigateway:index:APIKeySource"
-        plain: true
-        description: |
-          The source for the apikey. This can either be a HEADER or AUTHORIZER. If `apiKeyRequired` is
-          set to true on a route, and this is not defined the value will default to HEADER.
-      staticRoutesBucket:
-        "$ref": "/aws/v6.59.1/schema.json#/resources/aws:s3%2Fbucket:Bucket"
-        description: |
-          Bucket to use for placing resources for static resources.  If not provided a default one will
-          be created on your behalf if any `StaticRoute`s are provided.
-      gatewayResponses:
-        type: object
-        additionalProperties:
-          "$ref": "#/types/aws-apigateway:index:SwaggerGatewayResponse"
-        plain: true
-        description: |
-          Define custom gateway responses for the API. This can be used to properly enable
-          CORS for Lambda Authorizers.
-      binaryMediaTypes:
-        type: array
-        items: 
-          type: string
-        plain: true
-        description: |
-          List of binary media types supported by the REST API. By default, the REST API supports only UTF-8-encoded text payloads. 
-          If importing an OpenAPI specification via the body argument, this corresponds to the x-amazon-apigateway-binary-media-types extension. 
-          If the argument value is provided and is different than the OpenAPI value, the argument value will override the OpenAPI value.
-      disableExecuteApiEndpoint:
-        type: boolean
-        description: |
-          Whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke
-          your API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that
-          clients use a custom domain name to invoke your API, disable the default endpoint. Defaults to false.
-      description:
-        type: string
-        description: |
-          Description of the REST API.
-      tags:
-        type: object
-        additionalProperties:
-          type: string
-        description: |
-          'Map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present,
-          tags with matching keys will overwrite those defined at the provider-level.
-    properties:
-      url:
-        type: string
-        description: |
-          The URL where the Rest API is exposed.
-      api:
-        "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2FrestApi:RestApi"
-        description: |
-          The underlying RestAPI resource.
-      deployment:
-        "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2Fdeployment:Deployment"
-        description: |
-          The underlying Deployment resource.
-      stage:
-        "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2Fstage:Stage"
-        description: |
-          The underlying Stage resource.
-      apiPolicy:
-        "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2FrestApiPolicy:RestApiPolicy"
-        description: |
-          The underlying RestAPIPolicy resource.
-    required:
-      - url
-      - api
-      - deployment
-      - stage
-    description: |
-      The RestAPI component offers a simple interface for creating a fully functional API Gateway REST API. The 
-      REST API can define any number of routes, each of which maps a path and HTTP method to one of (1) an event 
-      hander route that invokes a Lambda Function (2) a local path route which uploads local files into an S3 bucket 
-      and serves them or (3) an integration target such as an HTTP proxy or service integration.
-language:
-  csharp:
-    namespaces:
-      aws-apigateway: AwsApiGateway
-    packageReferences:
-      Pulumi: 3.*
-      Pulumi.Aws: 6.*
-    respectSchemaVersion: true
-  go:
-    importBasePath: github.com/pulumi/pulumi-aws-apigateway/sdk/v2/go/apigateway
-    respectSchemaVersion: true
-    generateExtraInputTypes: true
-    internalModuleName: utilities
-  nodejs:
-    dependencies:
-      "@pulumi/aws": "^6.59.1"
-    respectSchemaVersion: true
-  python:
-    requires:
-      pulumi-aws: ">=6.59.1,<7.0.0"
-    respectSchemaVersion: true
-    pyproject:
-      enabled: true
-  java:
-    dependencies:
-      "com.pulumi:aws": "6.59.1"
+{
+  "name": "aws-apigateway",
+  "description": "Pulumi Amazon Web Services (AWS) API Gateway Components.",
+  "repository": "https://github.com/pulumi/pulumi-aws-apigateway",
+  "license": "Apache-2.0",
+  "logoUrl": "https://raw.githubusercontent.com/pulumi/pulumi-aws-apigateway/main/assets/logo.png",
+  "displayName": "AWS API Gateway",
+  "publisher": "Pulumi",
+  "keywords": [
+    "pulumi",
+    "aws",
+    "apigateway",
+    "category/cloud",
+    "kind/component"
+  ],
+  "types": {
+    "aws-apigateway:index:Route": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "plain": true,
+          "description": "The path on the API that will serve this route.  If not prefixed with `/`,\nthen a `/` will be added automatically to the beginning.\n"
+        },
+        "method": {
+          "$ref": "#/types/aws-apigateway:index:Method",
+          "plain": true,
+          "description": "The REST method of the route to match.  Only valid with `eventHandler` or `data` routes.\n"
+        },
+        "eventHandler": {
+          "$ref": "/aws/v6.59.1/schema.json#/resources/aws:lambda%2Ffunction:Function",
+          "description": "A Lambda function which will handle the route for the given path and method.\n"
+        },
+        "localPath": {
+          "type": "string",
+          "plain": true,
+          "description": "The local path on disk to create static S3 resources for.  Files will be uploaded into S3\nobjects, and directories will be recursively walked into.\n"
+        },
+        "contentType": {
+          "type": "string",
+          "plain": true,
+          "description": "The `content-type` to serve the file as.  Only valid when `localPath` points to a file.  If\n`localPath` points to a directory, the content types for all files will be inferred.\n"
+        },
+        "index": {
+          "oneOf": [
+            {
+              "type": "string",
+              "plain": true
+            },
+            {
+              "type": "boolean",
+              "plain": true
+            }
+          ],
+          "plain": true,
+          "description": "By default a `localPath` hosting static content will also serve 'index.html' in response to a request on a directory.\nTo disable this pass `false` or supply a new index document name.\n"
+        },
+        "data": {
+          "$ref": "pulumi.json#/Any",
+          "plain": true,
+          "description": "A raw Swagger object to include verbatim in the integration for this path.\n"
+        },
+        "target": {
+          "$ref": "#/types/aws-apigateway:index:Target",
+          "description": "The target for an integration route (see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-integration-types.html).\n"
+        },
+        "requiredParameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws-apigateway:index:RequiredParameter",
+            "plain": true
+          },
+          "plain": true,
+          "description": "Required Parameters to validate. If the request validator is set to ALL or PARAMS_ONLY, api\ngateway will validate these before sending traffic to the event handler.\n"
+        },
+        "requestValidator": {
+          "$ref": "#/types/aws-apigateway:index:RequestValidator",
+          "plain": true,
+          "description": "Request Validator specifies the validator to use at the method level. This will override anything\ndefined at the API level.\n"
+        },
+        "apiKeyRequired": {
+          "type": "boolean",
+          "plain": true,
+          "description": "If true, an API key will be required for this route. The source for the API Key can be set at\nthe API level and by default, the source will be the HEADER.\n"
+        },
+        "authorizers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws-apigateway:index:Authorizer",
+            "plain": true
+          },
+          "plain": true,
+          "description": "Authorizers allows you to define Lambda authorizers be applied for authorization when the\nthe route is called.\n"
+        },
+        "iamAuthEnabled": {
+          "type": "boolean",
+          "plain": true,
+          "description": "By default, the route method auth type is set to `NONE`. If true, the auth type will be\nset to `AWS_IAM`.\n"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "description": "A route that that APIGateway should accept and forward to some type of destination. All routes\nhave an incoming path that they match against.  However, destinations are determined by the kind\nof the route.\n"
+    },
+    "aws-apigateway:index:Target": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/types/aws-apigateway:index:IntegrationType",
+          "description": "Specifies an API method integration type. The valid value is one of the following:\n\n* `aws`: for integrating the API method request with an AWS service action, including the Lambda\nfunction-invoking action. With the Lambda function-invoking action, this is referred to as\nthe Lambda custom integration. With any other AWS service action, this is known as AWS\nintegration.\n\n* `aws_proxy`: for integrating the API method request with the Lambda function-invoking action\nwith the client request passed through as-is. This integration is also referred to as the\nLambda proxy integration.\n\n* `http`: for integrating the API method request with an HTTP endpoint, including a private HTTP\nendpoint within a VPC. This integration is also referred to as the HTTP custom integration.\n\n* `http_proxy`: for integrating the API method request with an HTTP endpoint, including a private\nHTTP endpoint within a VPC, with the client request passed through as-is. This is also\nreferred to as the HTTP proxy integration.\n\n* `mock`: for integrating the API method request with API Gateway as a \"loop-back\" endpoint\nwithout invoking any backend.\n"
+        },
+        "httpMethod": {
+          "type": "string",
+          "const": "ANY",
+          "description": "Specifies the integration's HTTP method type.  Currently, the only supported type is 'ANY'.\n"
+        },
+        "uri": {
+          "type": "string",
+          "description": "Specifies Uniform Resource Identifier (URI) of the integration endpoint.\n\nFor HTTP or HTTP_PROXY integrations, the URI must be a fully formed, encoded HTTP(S) URL\naccording to the RFC-3986 specification, for either standard integration, where\nconnectionType is not VPC_LINK, or private integration, where connectionType is VPC_LINK. For\na private HTTP integration, the URI is not used for routing.\n\nFor AWS or AWS_PROXY integrations, the URI is of the form\narn:aws:apigateway:{region}:{subdomain.service|service}:path|action/{service_api}. Here,\n{Region} is the API Gateway region (e.g., us-east-1); {service} is the name of the integrated\nAWS service (e.g., s3); and {subdomain} is a designated subdomain supported by certain AWS\nservice for fast host-name lookup. action can be used for an AWS service action-based API,\nusing an Action={name}&{p1}={v1}&p2={v2}... query string. The ensuing {service_api} refers to\na supported action {name} plus any required input parameters. Alternatively, path can be used\nfor an AWS service path-based API. The ensuing service_api refers to the path to an AWS\nservice resource, including the region of the integrated AWS service, if applicable. For\nexample, for integration with the S3 API of GetObject, the uri can be either\narn:aws:apigateway:us-west-2:s3:action/GetObject&Bucket={bucket}&Key={key} or\narn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}.\n"
+        },
+        "connectionType": {
+          "$ref": "#/types/aws-apigateway:index:IntegrationConnectionType",
+          "description": "The type of the network connection to the integration endpoint. The valid value is `INTERNET`\nfor connections through the public routable internet or `VPC_LINK` for private connections\nbetween API Gateway and a network load balancer in a VPC. The default value is `INTERNET`.\n"
+        },
+        "connectionId": {
+          "type": "string",
+          "description": "The (id) of the VpcLink used for the integration when connectionType=VPC_LINK and undefined,\notherwise.\n"
+        },
+        "passthroughBehaviour": {
+          "$ref": "#/types/aws-apigateway:index:IntegrationPassthroughBehavior",
+          "description": "Specifies how the method request body of an unmapped content type will be passed through the\nintegration request to the back end without transformation.\n\nThe valid value is one of the following:\n\n* `WHEN_NO_MATCH`: passes the method request body through the integration request to the back end\nwithout transformation when the method request content type does not match any content type\nassociated with the mapping templates defined in the integration request.\n\n* `WHEN_NO_TEMPLATES`: passes the method request body through the integration request to the back\nend without transformation when no mapping template is defined in the integration request. If\na template is defined when this option is selected, the method request of an unmapped\ncontent-type will be rejected with an HTTP 415 Unsupported Media Type response.\n\n* `NEVER`: rejects the method request with an HTTP 415 Unsupported Media Type response when\neither the method request content type does not match any content type associated with the\nmapping templates defined in the integration request or no mapping template is defined in the\nintegration request.\n\nDefaults to `WHEN_NO_MATCH` if unspecified.\n"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "aws-apigateway:index:Method": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "ANY"
+        },
+        {
+          "value": "GET"
+        },
+        {
+          "value": "PUT"
+        },
+        {
+          "value": "POST"
+        },
+        {
+          "value": "DELETE"
+        },
+        {
+          "value": "PATCH"
+        },
+        {
+          "value": "OPTIONS"
+        },
+        {
+          "value": "HEAD"
+        }
+      ]
+    },
+    "aws-apigateway:index:RequestValidator": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "ALL"
+        },
+        {
+          "value": "PARAMS_ONLY"
+        },
+        {
+          "value": "BODY_ONLY"
+        }
+      ]
+    },
+    "aws-apigateway:index:APIKeySource": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "HEADER"
+        },
+        {
+          "value": "AUTHORIZER"
+        }
+      ]
+    },
+    "aws-apigateway:index:IntegrationConnectionType": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "INTERNET"
+        },
+        {
+          "value": "VPC_LINK"
+        }
+      ]
+    },
+    "aws-apigateway:index:IntegrationType": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "aws"
+        },
+        {
+          "value": "aws_proxy"
+        },
+        {
+          "value": "http"
+        },
+        {
+          "value": "http_proxy"
+        },
+        {
+          "value": "mock"
+        }
+      ]
+    },
+    "aws-apigateway:index:IntegrationPassthroughBehavior": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "when_no_match"
+        },
+        {
+          "value": "when_no_templates"
+        },
+        {
+          "value": "never"
+        }
+      ]
+    },
+    "aws-apigateway:index:SwaggerGatewayResponse": {
+      "type": "object",
+      "properties": {
+        "statusCode": {
+          "type": "number"
+        },
+        "responseTemplates": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "responseParameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "aws-apigateway:index:RequiredParameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            {
+              "value": "path"
+            },
+            {
+              "value": "query"
+            },
+            {
+              "value": "header"
+            }
+          ]
+        }
+      }
+    },
+    "aws-apigateway:index:Authorizer": {
+      "type": "object",
+      "properties": {
+        "authorizerName": {
+          "type": "string",
+          "plain": true,
+          "description": "The name for the Authorizer to be referenced as. This must be unique for each unique\nauthorizer within the API. If no name if specified, a name will be generated for you.\n"
+        },
+        "parameterName": {
+          "type": "string",
+          "plain": true,
+          "description": "parameterName is the name of the header or query parameter containing the authorization\ntoken. Must be \"Unused\" for multiple identity sources.\n"
+        },
+        "parameterLocation": {
+          "type": "string",
+          "enum": [
+            {
+              "value": "query"
+            },
+            {
+              "value": "header"
+            }
+          ],
+          "plain": true,
+          "description": "Defines where in the request API Gateway should look for identity information. The value must\nbe \"header\" or \"query\". If there are multiple identity sources, the value must be \"header\".\n"
+        },
+        "authType": {
+          "type": "string",
+          "plain": true,
+          "description": "Specifies the authorization mechanism for the client. Typical values are \"oauth2\" or \"custom\".\n"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            {
+              "value": "token"
+            },
+            {
+              "value": "request"
+            }
+          ],
+          "plain": true,
+          "description": "The type of the authorizer. This value must be one of the following:\n- \"token\", for an authorizer with the caller identity embedded in an authorization token\n- \"request\", for an authorizer with the caller identity contained in request parameters\n"
+        },
+        "handler": {
+          "$ref": "/aws/v6.59.1/schema.json#/resources/aws:lambda%2Ffunction:Function",
+          "description": "The authorizerHandler specifies information about the authorizing Lambda.\n"
+        },
+        "identitySource": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "plain": true
+          },
+          "plain": true,
+          "description": "List of mapping expressions of the request parameters as the identity source. This indicates\nwhere in the request identity information is expected. Applicable for the authorizer of the\n\"request\" type only. Example: [\"method.request.header.HeaderAuth1\",\n\"method.request.querystring.QueryString1\"]\n"
+        },
+        "identityValidationExpression": {
+          "type": "string",
+          "plain": true,
+          "description": "A regular expression for validating the token as the incoming identity. It only invokes the\nauthorizer's lambda if there is a match, else it will return a 401. This does not apply to\nREQUEST Lambda Authorizers. Example: \"^x-[a-z]+\".\n"
+        },
+        "authorizerResultTtlInSeconds": {
+          "type": "number",
+          "plain": true,
+          "description": "The number of seconds during which the resulting IAM policy is cached. Default is 300s. You\ncan set this value to 0 to disable caching. Max value is 3600s. Note - if you are sharing an\nauthorizer across more than one route you will want to disable the cache or else it will\ncause problems for you.\n"
+        },
+        "providerARNs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "plain": true,
+          "description": "The ARNs of the Cognito User Pools to use.\n"
+        },
+        "methodsToAuthorize": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "plain": true
+          },
+          "plain": true,
+          "description": "For method authorization, you can define resource servers and custom scopes by specifying the\n\"resource-server/scope\". e.g. [\"com.hamuta.movies/drama.view\",\n\"http://my.resource.com/file.read\"] For more information on resource servers and custom\nscopes visit the AWS documentation -\nhttps://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-define-resource-servers.html\n"
+        }
+      },
+      "required": [
+        "parameterName"
+      ],
+      "description": "LambdaAuthorizer provides the definition for a custom Authorizer for API Gateway.\n"
+    }
+  },
+  "resources": {
+    "aws-apigateway:index:RestAPI": {
+      "isComponent": true,
+      "inputProperties": {
+        "routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/aws-apigateway:index:Route",
+            "plain": true
+          },
+          "plain": true,
+          "description": "Routes to use to initialize the APIGateway.  These will be used to create the Swagger\nspecification for the API.\n\nEither `swaggerString` or `routes` must be specified.\n"
+        },
+        "swaggerString": {
+          "type": "string",
+          "description": "A Swagger specification already in string form to use to initialize the APIGateway.  Note\nthat you must manually provide permission for any route targets to be invoked by API Gateway\nwhen using `swaggerString`.\n\nEither `swaggerString` or `routes` must be specified.\n"
+        },
+        "stageName": {
+          "type": "string",
+          "description": "The stage name for your API. This will get added as a base path to your API url.\n"
+        },
+        "requestValidator": {
+          "$ref": "#/types/aws-apigateway:index:RequestValidator",
+          "plain": true,
+          "description": "Request Validator specifies the validator to use at the API level. Note method level validators\noverride this.\n"
+        },
+        "apiKeySource": {
+          "$ref": "#/types/aws-apigateway:index:APIKeySource",
+          "plain": true,
+          "description": "The source for the apikey. This can either be a HEADER or AUTHORIZER. If `apiKeyRequired` is\nset to true on a route, and this is not defined the value will default to HEADER.\n"
+        },
+        "staticRoutesBucket": {
+          "$ref": "/aws/v6.59.1/schema.json#/resources/aws:s3%2Fbucket:Bucket",
+          "description": "Bucket to use for placing resources for static resources.  If not provided a default one will\nbe created on your behalf if any `StaticRoute`s are provided.\n"
+        },
+        "gatewayResponses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/aws-apigateway:index:SwaggerGatewayResponse"
+          },
+          "plain": true,
+          "description": "Define custom gateway responses for the API. This can be used to properly enable\nCORS for Lambda Authorizers.\n"
+        },
+        "binaryMediaTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "plain": true,
+          "description": "List of binary media types supported by the REST API. By default, the REST API supports only UTF-8-encoded text payloads. \nIf importing an OpenAPI specification via the body argument, this corresponds to the x-amazon-apigateway-binary-media-types extension. \nIf the argument value is provided and is different than the OpenAPI value, the argument value will override the OpenAPI value.\n"
+        },
+        "disableExecuteApiEndpoint": {
+          "type": "boolean",
+          "description": "Whether clients can invoke your API by using the default execute-api endpoint. By default, clients can invoke\nyour API with the default https://{api_id}.execute-api.{region}.amazonaws.com endpoint. To require that\nclients use a custom domain name to invoke your API, disable the default endpoint. Defaults to false.\n"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the REST API.\n"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "'Map of tags to assign to the resource. If configured with a provider `defaultTags` configuration block present,\ntags with matching keys will overwrite those defined at the provider-level.\n"
+        }
+      },
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "The URL where the Rest API is exposed.\n"
+        },
+        "api": {
+          "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2FrestApi:RestApi",
+          "description": "The underlying RestAPI resource.\n"
+        },
+        "deployment": {
+          "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2Fdeployment:Deployment",
+          "description": "The underlying Deployment resource.\n"
+        },
+        "stage": {
+          "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2Fstage:Stage",
+          "description": "The underlying Stage resource.\n"
+        },
+        "apiPolicy": {
+          "$ref": "/aws/v6.59.1/schema.json#/resources/aws:apigateway%2FrestApiPolicy:RestApiPolicy",
+          "description": "The underlying RestAPIPolicy resource.\n"
+        }
+      },
+      "required": [
+        "url",
+        "api",
+        "deployment",
+        "stage"
+      ],
+      "description": "The RestAPI component offers a simple interface for creating a fully functional API Gateway REST API. The \nREST API can define any number of routes, each of which maps a path and HTTP method to one of (1) an event \nhander route that invokes a Lambda Function (2) a local path route which uploads local files into an S3 bucket \nand serves them or (3) an integration target such as an HTTP proxy or service integration.\n"
+    }
+  },
+  "language": {
+    "csharp": {
+      "namespaces": {
+        "aws-apigateway": "AwsApiGateway"
+      },
+      "packageReferences": {
+        "Pulumi": "3.*",
+        "Pulumi.Aws": "6.*"
+      },
+      "respectSchemaVersion": true
+    },
+    "go": {
+      "importBasePath": "github.com/pulumi/pulumi-aws-apigateway/sdk/v2/go/apigateway",
+      "respectSchemaVersion": true,
+      "generateExtraInputTypes": true,
+      "internalModuleName": "utilities"
+    },
+    "nodejs": {
+      "dependencies": {
+        "@pulumi/aws": "^6.59.1"
+      },
+      "respectSchemaVersion": true
+    },
+    "python": {
+      "requires": {
+        "pulumi-aws": ">=6.59.1,<7.0.0"
+      },
+      "respectSchemaVersion": true,
+      "pyproject": {
+        "enabled": true
+      }
+    },
+    "java": {
+      "dependencies": {
+        "com.pulumi:aws": "6.59.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Convert the copied schema to json as schema-tool only works with JSON. Required to on-board to ci-mgmt.