### PR TITLE
Pin golangci-lint to 2.7.0 to fix lint CI failure

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+golangci-lint = "2.7.0"


### PR DESCRIPTION
## Summary

- Pins `golangci-lint` to `2.7.0` via a root-level `mise.toml`, overriding the autogenerated `.config/mise.toml`.
- Fixes the lint job failure reported in #650 (triggered by PR #649)

Closes #650

## Test plan

- [x] `mise install` resolves golangci-lint 2.7.0
- [x] `make lint` passes locally with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)