### PR TITLE
Use provider partition for API Gateway integration URIs

### DIFF
--- a/aws-apigateway/apigateway/api.ts
+++ b/aws-apigateway/apigateway/api.ts
@@ -23,7 +23,7 @@ import * as pulumi from "@pulumi/pulumi";
 
 import type * as awslambda from "aws-lambda";
 
-import { getRegion, ifUndefined, sha1hash } from "./utils";
+import { getPartition, getRegion, ifUndefined, sha1hash } from "./utils";
 
 import { apiKeySecurityDefinition } from "./apikey";
 import * as cognitoAuthorizer from "./cognitoAuthorizer";
@@ -1028,8 +1028,9 @@ function addEventHandlerRouteToSwaggerSpec(
   return;
 
   function createSwaggerOperationForLambda(): SwaggerOperation {
+    const partition = getPartition(parent);
     const region = getRegion(parent);
-    const uri = pulumi.interpolate`arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda.arn}/invocations`;
+    const uri = pulumi.interpolate`arn:${partition}:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda.arn}/invocations`;
 
     return {
       "x-amazon-apigateway-integration": {
@@ -1432,9 +1433,10 @@ function addStaticRouteToSwaggerSpec(
     role: aws.iam.Role,
     pathParameter?: string
   ): SwaggerOperation {
+    const partition = getPartition(bucket);
     const region = getRegion(bucket);
 
-    const uri = pulumi.interpolate`arn:aws:apigateway:${region}:s3:path/${
+    const uri = pulumi.interpolate`arn:${partition}:apigateway:${region}:s3:path/${
       bucket.bucket
     }/${objectKey}${pathParameter ? `/{${pathParameter}}` : ``}`;
 

--- a/aws-apigateway/apigateway/utils.ts
+++ b/aws-apigateway/apigateway/utils.ts
@@ -121,3 +121,9 @@ export function getRegion(res: pulumi.Resource): pulumi.Output<aws.Region> {
     // uses the provider from the parent resource to fetch the region
     return aws.getRegionOutput({}, { parent: res }).apply(region => region.name as aws.Region);
 }
+
+/** @internal */
+export function getPartition(res: pulumi.Resource): pulumi.Output<string> {
+    // uses the provider from the parent resource to fetch the partition
+    return aws.getPartitionOutput({}, { parent: res }).apply(partition => partition.partition);
+}

--- a/aws-apigateway/package.json
+++ b/aws-apigateway/package.json
@@ -22,6 +22,7 @@
     "format": "prettier -w .",
     "dedupe-deps": "yarn-deduplicate",
     "check-duplicate-deps": "yarn-deduplicate --fail",
-    "build": "SCHEMA=../provider/cmd/pulumi-resource-aws-apigateway/schema-embed.json ./scripts/build.sh"
+    "build": "SCHEMA=../provider/cmd/pulumi-resource-aws-apigateway/schema-embed.json ./scripts/build.sh",
+    "test": "yarn tsc && node bin/tests/partition.js"
   }
 }

--- a/aws-apigateway/tests/partition.ts
+++ b/aws-apigateway/tests/partition.ts
@@ -1,0 +1,101 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+import { RestAPI } from "../restAPI";
+
+type RestApiBodies = Record<string, pulumi.Input<string> | undefined>;
+
+function resolveOutput<T>(value: pulumi.Input<T>): Promise<T> {
+  return new Promise((resolve) => {
+    pulumi.output(value).apply((resolved) => {
+      resolve(resolved as T);
+      return resolved;
+    });
+  });
+}
+
+async function main() {
+  const restApiBodies: RestApiBodies = {};
+
+  await pulumi.runtime.setMocks({
+    call: ({ token }) => {
+      switch (token) {
+      case "aws:index/getPartition:getPartition":
+        return {
+          dnsSuffix: "amazonaws.com.cn",
+          id: "aws-cn",
+          partition: "aws-cn",
+          reverseDnsPrefix: "cn.com.amazonaws",
+        };
+      case "aws:index/getRegion:getRegion":
+        return { name: "cn-northwest-1" };
+      default:
+        return {};
+      }
+    },
+    newResource: ({ type, name, inputs }) => {
+      if (type === "aws:apigateway/restApi:RestApi") {
+        restApiBodies[name] = inputs.body;
+      }
+
+      return {
+        id: `${name}-id`,
+        state: inputs,
+      };
+    },
+  });
+
+  const lambda = new aws.lambda.Function("lambda-route-fn", {
+    code: new pulumi.asset.AssetArchive({
+      "index.js": new pulumi.asset.StringAsset("exports.handler = async () => ({ statusCode: 200, body: 'ok' });"),
+    }),
+    handler: "index.handler",
+    role: "arn:aws-cn:iam::123456789012:role/example",
+    runtime: "nodejs22.x",
+  });
+
+  new RestAPI("lambda-api", <any>{
+    routes: [<any>{
+      eventHandler: lambda,
+      method: "GET",
+      path: "/",
+    }],
+  });
+
+  const staticDir = fs.mkdtempSync(path.join(os.tmpdir(), "apigw-static-"));
+  fs.writeFileSync(path.join(staticDir, "index.html"), "hello");
+
+  new RestAPI("static-api", <any>{
+    routes: [<any>{
+      localPath: staticDir,
+      path: "/assets",
+    }],
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  const lambdaBody = await resolveOutput(restApiBodies["lambda-api"]);
+  const staticBody = await resolveOutput(restApiBodies["static-api"]);
+
+  assert.ok(lambdaBody);
+  assert.ok(staticBody);
+
+  assert.match(
+    lambdaBody as string,
+    /arn:aws-cn:apigateway:cn-northwest-1:lambda:path\/2015-03-31\/functions\//,
+  );
+  assert.match(
+    staticBody as string,
+    /arn:aws-cn:apigateway:cn-northwest-1:s3:path\//,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Related to #347

This fixes API Gateway integration URIs in China regions.
Right now the partition is hardcoded as `aws`, so Lambda and S3 integrations come out as `arn:aws:apigateway:cn-northwest-1:...`. Thats not it, China needs `aws-cn`.

How to repro
1. Use a provider with `region: "cn-northwest-1"`.
2. Create a `RestAPI` with either an existing `aws.lambda.Function` route, or a `localPath` static route.
3. Preview or inspect the generated swagger body.

Before:
`arn:aws:apigateway:cn-northwest-1:...`

After:
`arn:aws-cn:apigateway:cn-northwest-1:...`

Ran `cd aws-apigateway && yarn test`.