### PR TITLE
Use provider partition for API Gateway integration URIs

### DIFF
--- a/aws-apigateway/apigateway/api.ts
+++ b/aws-apigateway/apigateway/api.ts
@@ -23,7 +23,7 @@ import * as pulumi from "@pulumi/pulumi";
 
 import type * as awslambda from "aws-lambda";
 
-import { getRegion, ifUndefined, sha1hash } from "./utils";
+import { getPartition, getRegion, ifUndefined, sha1hash } from "./utils";
 
 import { apiKeySecurityDefinition } from "./apikey";
 import * as cognitoAuthorizer from "./cognitoAuthorizer";
@@ -1028,8 +1028,9 @@ function addEventHandlerRouteToSwaggerSpec(
   return;
 
   function createSwaggerOperationForLambda(): SwaggerOperation {
+    const partition = getPartition(parent);
     const region = getRegion(parent);
-    const uri = pulumi.interpolate`arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda.arn}/invocations`;
+    const uri = pulumi.interpolate`arn:${partition}:apigateway:${region}:lambda:path/2015-03-31/functions/${lambda.arn}/invocations`;
 
     return {
       "x-amazon-apigateway-integration": {
@@ -1432,9 +1433,10 @@ function addStaticRouteToSwaggerSpec(
     role: aws.iam.Role,
     pathParameter?: string
   ): SwaggerOperation {
+    const partition = getPartition(bucket);
     const region = getRegion(bucket);
 
-    const uri = pulumi.interpolate`arn:aws:apigateway:${region}:s3:path/${
+    const uri = pulumi.interpolate`arn:${partition}:apigateway:${region}:s3:path/${
       bucket.bucket
     }/${objectKey}${pathParameter ? `/{${pathParameter}}` : ``}`;
 

--- a/aws-apigateway/apigateway/utils.ts
+++ b/aws-apigateway/apigateway/utils.ts
@@ -121,3 +121,9 @@ export function getRegion(res: pulumi.Resource): pulumi.Output<aws.Region> {
     // uses the provider from the parent resource to fetch the region
     return aws.getRegionOutput({}, { parent: res }).apply(region => region.name as aws.Region);
 }
+
+/** @internal */
+export function getPartition(res: pulumi.Resource): pulumi.Output<string> {
+    // uses the provider from the parent resource to fetch the partition
+    return aws.getPartitionOutput({}, { parent: res }).apply(partition => partition.partition);
+}


### PR DESCRIPTION
Integration URIs for Lambda and S3 static routes hardcoded the `aws` partition, so in China (`aws-cn`) and GovCloud (`aws-us-gov`) regions the generated ARNs were wrong (e.g. `arn:aws:apigateway:cn-northwest-1:...` instead of `arn:aws-cn:...`) and the integrations would not resolve. This derives the partition from the provider via `getPartitionOutput`, mirroring the existing `getRegion` helper.

Supersedes #752 (source fix by @immanuwell). Fixes #347.

## Test plan

- `yarn tsc` passes.
- Partition correctness is a pure output transformation and can't be covered by the Go example tests (they deploy to a commercial-partition account with no `aws-cn`/`aws-us-gov` credentials). The component has no TS unit-test lane today; establishing one is tracked separately rather than bundled here.