### PR TITLE
Stop Renovate from discarding CI's regenerated SDK commits

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,25 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>pulumi/renovate-config//default.json5"],
+
+  // Don't let Renovate recreate a branch after CI has committed regenerated
+  // SDKs onto it.
+  //
+  // build_sdk.yml regenerates sdk/ on Renovate PRs and pushes the result back
+  // as pulumi-bot. The shared preset lists pulumi-bot in gitIgnoredAuthors, so
+  // Renovate does not count that commit as a third-party modification and
+  // stays free to rebuild the branch from master on its next run, which drops
+  // the codegen commit. build_sdk then regenerates and pushes it again, and
+  // the two ping-pong indefinitely.
+  //
+  // Clearing the list makes Renovate treat the branch as modified and leave it
+  // alone once pulumi-bot has pushed, so the codegen commit survives and the
+  // PR can go green. gitIgnoredAuthors is not a mergeable option, so this
+  // replaces the preset's list rather than extending it.
+  //
+  // Trade-off: Renovate will no longer bump such a branch to newer versions or
+  // rebase it if master moves into conflict; both need doing by hand.
+  gitIgnoredAuthors: [],
   packageRules: [
     {
       matchDatasources: ["npm", "go", "golang-version"],


### PR DESCRIPTION
`build_sdk.yml` regenerates `sdk/` on Renovate PRs and pushes the result back as pulumi-bot. The shared preset lists pulumi-bot in `gitIgnoredAuthors`, so Renovate does not count that commit as a third-party modification and stays free to rebuild the branch from the base on its next run, which drops the codegen commit. build_sdk then regenerates and pushes it again, and the two ping-pong. On #730 that loop has produced hundreds of force-pushes, every one discarding the SDK commit CI had just pushed.

Clearing `gitIgnoredAuthors` for this repo makes Renovate treat the branch as modified and leave it alone once pulumi-bot has pushed, so the codegen commit survives and the PR can reach a green run.

`gitIgnoredAuthors` is not a mergeable option, so `[]` replaces the preset's list rather than extending it.

Trade-off: Renovate will no longer bump such a branch to newer versions, nor rebase it if master moves into conflict. Both need doing by hand.

Part of pulumi/home#4904
